### PR TITLE
Update Latin tokenizer to handle 'neque'

### DIFF
--- a/cltk/tests/test_tokenize.py
+++ b/cltk/tests/test_tokenize.py
@@ -63,7 +63,8 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         
         tests = ['Arma virumque cano, Troiae qui primus ab oris.',
                     'Hoc verumst, tota te ferri, Cynthia, Roma, et non ignota vivere nequitia?',
-                    'Nec te decipiant veteres circum atria cerae. Tolle tuos tecum, pauper amator, avos!']
+                    'Nec te decipiant veteres circum atria cerae. Tolle tuos tecum, pauper amator, avos!',
+                    'Neque enim, quod quisque potest, id ei licet, nec, si non obstatur, propterea etiam permittitur.']
         
         results = []
         
@@ -73,7 +74,8 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
                     
         target = [['Arma', 'que', 'virum', 'cano', ',', 'Troiae', 'qui', 'primus', 'ab', 'oris.'],
                     ['Hoc', 'verum', 'est', ',', 'tota', 'te', 'ferri', ',', 'Cynthia', ',', 'Roma', ',', 'et', 'non', 'ignota', 'vivere', 'nequitia', '?'],
-                    ['Nec', 'te', 'decipiant', 'veteres', 'circum', 'atria', 'cerae.', 'Tolle', 'tuos', 'cum', 'te', ',', 'pauper', 'amator', ',', 'avos', '!']]
+                    ['Nec', 'te', 'decipiant', 'veteres', 'circum', 'atria', 'cerae.', 'Tolle', 'tuos', 'cum', 'te', ',', 'pauper', 'amator', ',', 'avos', '!'],
+                    ['que', 'Ne', 'enim', ',', 'quod', 'quisque', 'potest', ',', 'id', 'ei', 'licet', ',', 'nec', ',', 'si', 'non', 'obstatur', ',', 'propterea', 'etiam', 'permittitur.']]
                     
         self.assertEqual(results, target)
 

--- a/cltk/tests/test_tokenize.py
+++ b/cltk/tests/test_tokenize.py
@@ -60,6 +60,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         # - V. Aen. 1.1
         # - Prop. 2.5.1-2
         # - Ov. Am. 1.8.65-66
+        # - Cic. Phillip. 13.14
         
         tests = ['Arma virumque cano, Troiae qui primus ab oris.',
                     'Hoc verumst, tota te ferri, Cynthia, Roma, et non ignota vivere nequitia?',

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -72,7 +72,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
             que_exceptions += ['absque', 'abusque', 'adaeque', 'adusque', 'aeque', 'antique', 'atque',
                                'circumundique', 'conseque', 'cumque', 'cunque', 'denique', 'deque',
                                'donique', 'hucusque', 'inique', 'inseque', 'itaque', 'longinque',
-                               'namque', 'neque', 'oblique', 'peraeque', 'praecoque', 'propinque',
+                               'namque', 'oblique', 'peraeque', 'praecoque', 'propinque',
                                'qualiscumque', 'quandocumque', 'quandoque', 'quantuluscumque',
                                'quantumcumque', 'quantuscumque', 'quinque', 'quocumque',
                                'quomodocumque', 'quomque', 'quotacumque', 'quotcumque',


### PR DESCRIPTION
Minor edit to Latin tokenizer—took 'neque' out of exceptions list, so that it tokenizes as:

'neque' > ['ne', 'que']

This follows the practice of Perseus NLP data.

Also, updated the corresponding test.