### PR TITLE
Update Latin word tokenizer to handle 'nec' 

### DIFF
--- a/cltk/tests/test_tokenize.py
+++ b/cltk/tests/test_tokenize.py
@@ -76,7 +76,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         target = [['Arma', 'que', 'virum', 'cano', ',', 'Troiae', 'qui', 'primus', 'ab', 'oris.'],
                     ['Hoc', 'verum', 'est', ',', 'tota', 'te', 'ferri', ',', 'Cynthia', ',', 'Roma', ',', 'et', 'non', 'ignota', 'vivere', 'nequitia', '?'],
                     ['Nec', 'te', 'decipiant', 'veteres', 'circum', 'atria', 'cerae.', 'Tolle', 'tuos', 'cum', 'te', ',', 'pauper', 'amator', ',', 'avos', '!'],
-                    ['que', 'Ne', 'enim', ',', 'quod', 'quisque', 'potest', ',', 'id', 'ei', 'licet', ',', 'nec', ',', 'si', 'non', 'obstatur', ',', 'propterea', 'etiam', 'permittitur.']]
+                    ['que', 'Ne', 'enim', ',', 'quod', 'quisque', 'potest', ',', 'id', 'ei', 'licet', ',', 'c', 'ne', ',', 'si', 'non', 'obstatur', ',', 'propterea', 'etiam', 'permittitur.']]
                     
         self.assertEqual(results, target)
 

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -164,6 +164,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
         """Tokenize incoming string."""
         punkt = PunktLanguageVars()
         generic_tokens = punkt.word_tokenize(string)
+        generic_tokens = [x for item in generic_tokens for x in ([item] if item != 'nec' else ['c', 'ne'])] # Handle 'nec' as a special case.
         specific_tokens = []
         for generic_token in generic_tokens:
             is_enclitic = False


### PR DESCRIPTION
Minor tweak—the tokenizer finds/replaces 'nec' with ['c', 'ne'] before looking at other enclitics/etc. Seemed easier to handle as a special case rather than try to match on final 'c'. Let me know if anyone thinks of a better way to handle this.