### PR TITLE
chore: rollback codecov version from 1.6.4 to 1.6.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 cltk==0.1.32
-codecov==1.6.4
+codecov==1.6.3
 coverage==4.0.3
 coveralls==1.1
 docopt==0.6.2


### PR DESCRIPTION
`dev-requirements.txt` used to specify the codecov install version as 1.6.4, but the latest version is 1.6.3.