### PR TITLE
Add ability to set metadata on TextReuse and Comparison classes

### DIFF
--- a/cltk/text_reuse/comparison.py
+++ b/cltk/text_reuse/comparison.py
@@ -28,55 +28,72 @@ class Comparison:
         self.ratio = distance_ratio
 
         # The authors related to the compared string values
-        # e.g. 10 (for line 10) or 3 (for paragraph 3)
-        self.author_a = ""
-        self.author_b = ""
+        self.author_a = None
+        self.author_b = None
 
         # The works related to the compared string values
-        # e.g. 10 (for line 10) or 3 (for paragraph 3)
-        self.work_a = ""
-        self.work_b = ""
+        self.work_a = None
+        self.work_b = None
 
         # The subworks related to the compared string values
-        # e.g. 10 (for line 10) or 3 (for paragraph 3)
-        self.subwork_a = ""
-        self.subwork_b = ""
+        self.subwork_a = None
+        self.subwork_b = None
 
         # The text numbers related to the compared string values
         # e.g. 10 (for line 10) or 3 (for paragraph 3)
         self.text_n_a = None
         self.text_n_b = None
 
+        # Languages of strings being compared
+        self.language_a = None
+        self.language_b = None
+
         return
 
-    def set_ref_a(author, work, subwork, text_n):
+    def set_ref_a(self, text_ref):
         """
         Set the reference values related to the str_a compared string
-        :param author: str
-        :param work: str
-        :param subwork: str
-        :param text_n: str (a string instead of integer for variations in numbering systems that may inlude integers and alpha characters (e.g. '101b'))
+        :param text_info: dict
+                    -- author: str
+                    -- work: str
+                    -- subwork: str
+                    -- text_n: str (a string instead of integer for variations in numbering systems that may inlude integers and alpha characters (e.g. '101b'))
         :return: void
         """
-        self.author_a = author
-        self.work_a = work
-        self.subwork_a = subwork
-        self.text_n_a = text_n
+
+        if 'author' in text_ref:
+            self.author_a = text_ref['author']
+        if 'work' in text_ref:
+            self.work_a = text_ref['work']
+        if 'subwork' in text_ref:
+            self.subwork_a = text_ref['subwork']
+        if 'text_n' in text_ref:
+            self.text_n_a = text_ref['text_n']
+        if 'language' in text_ref:
+            self.language_a = text_ref['language']
 
         return
 
-    def set_ref_b(author, work, subwork, text_n):
+    def set_ref_b(self, text_ref):
         """
         Set the reference values related to the str_b compared string
-        :param author: str
-        :param work: str
-        :param subwork: str
-        :param text_n: str (a string instead of integer for variations in numbering systems that may inlude integers and alpha characters (e.g. '101b'))
+        :param text_info: dict
+                    -- author: str
+                    -- work: str
+                    -- subwork: str
+                    -- text_n: str (a string instead of integer for variations in numbering systems that may inlude integers and alpha characters (e.g. '101b'))
         :return: void
         """
-        self.author_b = author
-        self.work_b = work
-        self.subwork_b = subwork
-        self.text_n_b = text_n
+
+        if 'author' in text_ref:
+            self.author_b = text_ref['author']
+        if 'work' in text_ref:
+            self.work_b = text_ref['work']
+        if 'subwork' in text_ref:
+            self.subwork_b = text_ref['subwork']
+        if 'text_n' in text_ref:
+            self.text_n_b = text_ref['text_n']
+        if 'language' in text_ref:
+            self.language_b = text_ref['language']
 
         return

--- a/cltk/text_reuse/text_reuse.py
+++ b/cltk/text_reuse/text_reuse.py
@@ -33,14 +33,12 @@ class TextReuse:
         :param text_b: dict
         :param stem_words: bool
         :param sanitize_input: bool
-        :param csv_output: bool
         """
 
         self.text_ref_a = text_ref_a
         self.text_ref_b = text_ref_b
         self.stem_words = stem_words
         self.sanitize_input = sanitize_input
-        self.csv_output = csv_output
 
         return
 

--- a/cltk/text_reuse/text_reuse.py
+++ b/cltk/text_reuse/text_reuse.py
@@ -26,15 +26,21 @@ class TextReuse:
     """
 
 
-    def __init__(self, stem_words=False, sanitize_input=False):
+    def __init__(self, text_ref_a=None, text_ref_b=None, stem_words=False, sanitize_input=False):
         """
         Indicate if text reuse class should stem words and/or sanitize_input before comparison
+        :param text_a: dict
+        :param text_b: dict
         :param stem_words: bool
         :param sanitize_input: bool
+        :param csv_output: bool
         """
 
+        self.text_ref_a = text_ref_a
+        self.text_ref_b = text_ref_b
         self.stem_words = stem_words
         self.sanitize_input = sanitize_input
+        self.csv_output = csv_output
 
         return
 
@@ -119,23 +125,40 @@ class TextReuse:
         comparisons = []
         l = Levenshtein()
 
+        # For all strings in list a
         for i, str_a in enumerate(list_a):
+
+            # Add a new list to our list of lists of comparisons
             comparisons.append([])
+
+            # Compare str_a to every string in list_b
             for str_b in list_b:
+
+                # If the sanitize, input flag is set, make the ratio with the sanitized values
                 if self.sanitize_input:
-                    comparisons[i].append(
-                            Comparison(
-                                str_a['text'],
-                                str_b['text'],
-                                l.ratio(str_a['sanitized'], str_b['sanitized'])
-                            ))
+                    new_comparison = Comparison(
+                                            str_a['text'],
+                                            str_b['text'],
+                                            l.ratio(str_a['sanitized'], str_b['sanitized'])
+                                        )
+
+                # Otherwise, make the ratio with the original, unsanitize text strings
                 else:
-                    comparisons[i].append(
-                            Comparison(
-                                str_a['text'],
-                                str_b['text'],
-                                l.ratio(str_a['text'], str_b['text'])
-                            ))
+                    new_comparison = Comparison(
+                                            str_a['text'],
+                                            str_b['text'],
+                                            l.ratio(str_a['text'], str_b['text'])
+                                        )
+
+                # If text metadata is set on this class for text a or b, save that data with the
+                # comparison
+                if self.text_ref_a:
+                    new_comparison.set_ref_a(self.text_ref_a)
+                if self.text_ref_b:
+                    new_comparison.set_ref_b(self.text_ref_b)
+
+                # Finally, append the new comparison to the list of comparisons
+                comparisons[i].append(new_comparison)
 
         return comparisons
 

--- a/contributors.md
+++ b/contributors.md
@@ -51,9 +51,11 @@ CLTK Core authors, ordered alphabetically by first name
 * cltk/utils/philology.py
 
 ## Luke Hollis <lukehollis@gmail.com>
-* cltk/reuse/levenshtein.py
 * cltk/stem/latin/stem.py
 * cltk/stem/latin/syllabifier.py
+* cltk/text_reuse/comparison.py
+* cltk/text_reuse/levenshtein.py
+* cltk/text_reuse/text_reuse.py
 
 ## Martín Pozzi <marpozzi@gmail.com>
 * cltk/corpus/greek/tlg/parse_tlg_indices.py
@@ -93,4 +95,3 @@ CLTK Core authors, ordered alphabetically by first name
 ## Tyler Kirby <joseph.kirby12@ncf.edu>
 * cltk/prosody/greek/scanner.py
 * cltk/prosody/latin/scanner.py
-


### PR DESCRIPTION
These changes allow a programmer working with the framework to set metadata for the TextReuse and Comparisons classes so that he/she may more easily study the comparisons generated by the module.  

An example of how I imagine a programmer might use these tools is in this repo: https://github.com/lukehollis/augustan-era-intertext/blob/master/intertext.py  It's necessary to add the author, work, and language metadata to the comparisons so that they may be more easily queried in the future. 