### PR TITLE
Fixed index error in Latin prosody code

### DIFF
--- a/cltk/prosody/latin/scanner.py
+++ b/cltk/prosody/latin/scanner.py
@@ -250,8 +250,9 @@ class Scansion:
                     scanned_sent.append('¯')
                 else:
                     scanned_sent.append('˘')
-            del scanned_sent[-1]
-            scanned_sent.append('x')
+            if len(scanned_sent) > 1:
+                del scanned_sent[-1]
+                scanned_sent.append('x')
             scanned_text.append(''.join(scanned_sent))
         return scanned_text
 


### PR DESCRIPTION
The anceps code fails on sentences that are only one character long (often chapter numbers), so this fixes that issue.