### PR TITLE
Regarding Issue:Normalize Unicode throughout CLTK #94

### DIFF
--- a/cltk/corpus/utils/formatter.py
+++ b/cltk/corpus/utils/formatter.py
@@ -15,6 +15,7 @@ from cltk.corpus.greek.tlg_index import TLG_WORKS_INDEX
 from cltk.corpus.latin.phi5_index import PHI5_INDEX
 from cltk.corpus.latin.phi5_index import PHI5_WORKS_INDEX
 from cltk.utils.cltk_logger import logger
+from unicodedata import normalize
 import os
 import regex
 
@@ -73,8 +74,13 @@ def tlg_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False):
 
     return text
 
+def cltk_normalize(text, compatibility=True):
+    if compatibility:
+        return normalize('NFKC', text)
+    else:
+        return normalize('NFC', text)
 
-def phi5_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False):
+def phi5_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False,compatibility=True):
     """Remove and substitute post-processing for Greek PHI5 text.
     TODO: Surely more junk to pull out. Please submit bugs!
     TODO: This is a rather slow now, help in speeding up welcome.
@@ -84,6 +90,9 @@ def phi5_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False):
     remove_comp = regex.compile(r'-\n|«|»|\<|\>|\.\.\.|‘|’|_|\{.+?\}|\(.+?\)|\(|\)|“|#|%|⚔|&|=|/|\\|〚|†|『|⚖|–|˘|⚕|☾|◌|◄|►|⌐|⌊|⌋|≈|∷|≈|∞|”|[0-9]')
     text = remove_comp.sub('', text)
 
+    #normalizing text to combine diacritics into precomposed characters
+    text=cltk_normalize(text,compatibility)
+
     new_text = None
     if rm_punctuation:
         new_text = ''
@@ -91,12 +100,8 @@ def phi5_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False):
         if rm_periods:
             punctuation += ['.']
         for char in text:
-            # rm acute combining acute accents made by TLGU
-            # Could be caught by regex, tried and failed, not sure why
-            if bytes(char, 'utf-8') == b'\xcc\x81':
-                pass
-            # second try at rming some punctuation; merge with above regex
-            elif char in punctuation:
+            #try at rming some punctuation; merge with above regex
+            if char in punctuation:
                 pass
             else:
                 new_text += char

--- a/cltk/tests/test_corpus.py
+++ b/cltk/tests/test_corpus.py
@@ -35,6 +35,8 @@ from cltk.corpus.utils.formatter import phi5_plaintext_cleanup
 from cltk.corpus.utils.formatter import remove_non_ascii
 from cltk.corpus.utils.formatter import tlg_plaintext_cleanup
 from cltk.corpus.utils.importer import CorpusImporter
+from cltk.corpus.utils.formatter import cltk_normalize
+from unicodedata import normalize
 import os
 import unittest
 
@@ -142,6 +144,23 @@ argenteo polubro, aureo eclutro. """
         clean = phi5_plaintext_cleanup(dirty, rm_punctuation=True, rm_periods=True)
         target = 'Ì Virum áge mihi'
         self.assertEqual(clean, target)
+
+    def test_cltk_normalize_compatible(self):
+        """Test Normalizing Text with compatibility True"""
+        s1 = 'café'
+        s2 = 'cafe\u0301'
+        normalized_text=cltk_normalize(s1,compatibility=True)
+        target=normalize('NFKC', s2)
+        self.assertEquals(normalized_text ,target)
+
+    def test_cltk_normalize_noncompatible(self):
+        """Test Normalizing Text with compatibility False"""
+        s1 = 'café'
+        s2 = 'cafe\u0301'
+        normalized_text=cltk_normalize(s1,compatibility=False)
+        target=normalize('NFC', s2)
+        self.assertEquals(normalized_text ,target)
+
 
     def test_assemble_tlg_author(self):
         """Test building absolute filepaths from TLG index."""


### PR DESCRIPTION
In formatter.py i am calling cltk_normalize() inside from phi5_plaintext_cleanup() , so i have added one more parameter "compatibility" , so should i add this parameter in test methods ,or is it ok.