### PR TITLE
Added sanskrit_parallel_gitasupersite

### DIFF
--- a/cltk/corpus/sanskrit/corpora.py
+++ b/cltk/corpus/sanskrit/corpora.py
@@ -11,4 +11,7 @@ SANSKRIT_CORPORA = [
         {'name':'sanskrit_text_sacred_texts',
         'location':'remote',
          'type':'text'},
+        {'name':'sanskrit_parallel_gitasupersite',
+         'location':'remote',
+         'type':'parallel'},
 ]

--- a/docs/sanskrit.rst
+++ b/docs/sanskrit.rst
@@ -14,6 +14,6 @@ Use ``CorpusImporter()`` or browse the `CLTK GitHub repository <https://github.c
 
    In [3]: c.list_corpora
    Out[3]:
-   ['sanskrit_text_jnu','sanskrit_text_dcs','sanskrit_parallel_sacred_texts','sanskrit_text_sacred_texts']
+   ['sanskrit_text_jnu', 'sanskrit_text_dcs', 'sanskrit_parallel_sacred_texts', 'sanskrit_text_sacred_texts', 'sanskrit_parallel_gitasupersite']
 
 


### PR DESCRIPTION
Added sanskrit parallel corpus([srimad-bhagavadgita](http://www.gitasupersite.iitk.ac.in/srimad?language=dv&field_chapter_value=1&field_nsutra_value=1) and [valmiki-ramayana](http://www.valmiki.iitk.ac.in/)) from <a href="http://www.gitasupersite.iitk.ac.in/">gitasupersite</a>.
- Corresponding repository : <a href="https://github.com/cltk/sanskrit_parallel_gitasupersite">/cltk/sanskrit_parallel_gitasupersite</a>