### PR TITLE
Added sanskrit_text_gita_supersite

### DIFF
--- a/cltk/corpus/sanskrit/corpora.py
+++ b/cltk/corpus/sanskrit/corpora.py
@@ -14,4 +14,7 @@ SANSKRIT_CORPORA = [
         {'name':'sanskrit_parallel_gitasupersite',
          'location':'remote',
          'type':'parallel'},
+        {'name':'sanskrit_text_gitasupersite',
+         'location':'remote',
+         'type':'text'},
 ]

--- a/docs/sanskrit.rst
+++ b/docs/sanskrit.rst
@@ -14,6 +14,6 @@ Use ``CorpusImporter()`` or browse the `CLTK GitHub repository <https://github.c
 
    In [3]: c.list_corpora
    Out[3]:
-   ['sanskrit_text_jnu', 'sanskrit_text_dcs', 'sanskrit_parallel_sacred_texts', 'sanskrit_text_sacred_texts', 'sanskrit_parallel_gitasupersite']
+   ['sanskrit_text_jnu', 'sanskrit_text_dcs', 'sanskrit_parallel_sacred_texts', 'sanskrit_text_sacred_texts', 'sanskrit_parallel_gitasupersite', 'sanskrit_text_gitasupersite']
 
 


### PR DESCRIPTION
Added sanskrit monolingual corpus([srimad-bhagavadgita](http://www.gitasupersite.iitk.ac.in/srimad?language=dv&field_chapter_value=1&field_nsutra_value=1) and [valmiki-ramayana](http://www.valmiki.iitk.ac.in/)) from <a href="http://www.gitasupersite.iitk.ac.in/">gitasupersite</a>.
- Corresponding repository : <a href="https://github.com/cltk/sanskrit_text_gitasupersite">/cltk/sanskrit_text_gitasupersite</a>
- Added scrappers(<a href="https://github.com/cltk/sanskrit_text_gitasupersite/blob/master/bhagavadgita/scrape.py">bhagavadgita</a> and <a href="https://github.com/cltk/sanskrit_text_gitasupersite/blob/master/ramayana/scrape.py">ramayana</a>) as well.