### PR TITLE
Fixed index error in Greek scanner class

### DIFF
--- a/cltk/corpus/multilingual/morpheus.py
+++ b/cltk/corpus/multilingual/morpheus.py
@@ -1,0 +1,22 @@
+"""Wrapper for Johan Winge's modified `morpheus` command line utility.
+
+Original software at: ``orig. software url``
+TODO: Find original software url
+TODO: Add Morpheus to cltk Corpus Importer?
+"""
+
+from cltk.utils.cltk_logger import logger
+import os
+import subprocess
+
+class Morpheus(object):
+    """Check, install, and call Morpheus"""
+    def __init__(self, testing=False):
+        """Check whether morpheus is installed, if not, import and install"""
+        self.testing = testing
+        self._check_import_source()
+        self._check_install()
+
+    @staticmethod
+    def _check_import_source():
+        """Check if Morpheus is installed, if not, install it"""

--- a/cltk/prosody/greek/scanner.py
+++ b/cltk/prosody/greek/scanner.py
@@ -193,8 +193,9 @@ class Scansion:
                     scanned_sent.append('¯')
                 else:
                     scanned_sent.append('˘')
-            del scanned_sent[-1]
-            scanned_sent.append('x')
+            if len(scanned_sent) > 1:
+                del scanned_sent[-1]
+                scanned_sent.append('x')
             scanned_text.append(''.join(scanned_sent))
         return scanned_text
 


### PR DESCRIPTION
The Greek scanner class suffered from the same error as the Latin scanner class previously did. This should fix any index errors that occur when sentences less than 1 token long are scanned.