### PR TITLE
Add feature to load Latin corpora directly using PlaintextCorpusReader

### DIFF
--- a/cltk/corpus/latin/__init__.py
+++ b/cltk/corpus/latin/__init__.py
@@ -1,0 +1,22 @@
+# CLTK: Latin Corpus Readers
+
+__author__ = 'Patrick J. Burns <patrick@diyclassics.org>'
+__license__ = 'MIT License. See LICENSE.'
+
+"""
+CLTK Latin corpus readers
+"""
+import os.path
+from nltk.corpus.reader.plaintext import PlaintextCorpusReader
+
+# Would like to have this search through a CLTK_DATA environment variable
+# Better to use something like make_cltk_path in cltk.utils.file_operations?
+home = os.path.expanduser('~')
+cltk_path = os.path.join(home, 'CLTK_DATA')
+
+# Latin Library
+try:
+    latinlibrary = PlaintextCorpusReader(cltk_path + '/latin/text/latin_text_latin_library', '.*\.txt', encoding='utf-8')
+    pass
+except IOError as e:
+    print("Corpus not found. Please check that the Latin Library is installed in CLTK_DATA.")


### PR DESCRIPTION
Using the Latin Library corpus as a test case, this feature allows
you to refer to a corpus and load it with PlaintextCorpusReader using
the following syntax:

from cltk.corpus.latin import latinlibrary

The code checks to make sure that a corpus is installed in the
main CLTK_DATA and raises an error if it is not there.