### PR TITLE
Updates to Latin tokenizer

### DIFF
--- a/cltk/corpus/latin/__init__.py
+++ b/cltk/corpus/latin/__init__.py
@@ -1,0 +1,22 @@
+# CLTK: Latin Corpus Readers
+
+__author__ = 'Patrick J. Burns <patrick@diyclassics.org>'
+__license__ = 'MIT License. See LICENSE.'
+
+"""
+CLTK Latin corpus readers
+"""
+import os.path
+from nltk.corpus.reader.plaintext import PlaintextCorpusReader
+
+# Would like to have this search through a CLTK_DATA environment variable
+# Better to use something like make_cltk_path in cltk.utils.file_operations?
+home = os.path.expanduser('~')
+cltk_path = os.path.join(home, 'CLTK_DATA')
+
+# Latin Library
+try:
+    latinlibrary = PlaintextCorpusReader(cltk_path + '/latin/text/latin_text_latin_library', '.*\.txt', encoding='utf-8')
+    pass
+except IOError as e:
+    print("Corpus not found. Please check that the Latin Library is installed in CLTK_DATA.")

--- a/cltk/tests/test_tokenize.py
+++ b/cltk/tests/test_tokenize.py
@@ -82,14 +82,14 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
             result = word_tokenizer.tokenize(test)
             results.append(result)
                     
-        target = [['Arma', 'que', 'virum', 'cano', ',', 'Troiae', 'qui', 'primus', 'ab', 'oris.'],
+        target = [['Arma', 'virum', '-que', 'cano', ',', 'Troiae', 'qui', 'primus', 'ab', 'oris.'],
                     ['Hoc', 'verum', 'est', ',', 'tota', 'te', 'ferri', ',', 'Cynthia', ',', 'Roma', ',', 'et', 'non', 'ignota', 'vivere', 'nequitia', '?'],
-                    ['c', 'Ne', 'te', 'decipiant', 'veteres', 'circum', 'atria', 'cerae.', 'Tolle', 'tuos', 'cum', 'te', ',', 'pauper', 'amator', ',', 'avos', '!'],
-                    ['que', 'Ne', 'enim', ',', 'quod', 'quisque', 'potest', ',', 'id', 'ei', 'licet', ',', 'c', 'ne', ',', 'si', 'non', 'obstatur', ',', 'propterea', 'etiam', 'permittitur.'],
+                    ['Nec', 'te', 'decipiant', 'veteres', 'circum', 'atria', 'cerae.', 'Tolle', 'tuos', 'cum', 'te', ',', 'pauper', 'amator', ',', 'avos', '!'],
+                    ['Neque', 'enim', ',', 'quod', 'quisque', 'potest', ',', 'id', 'ei', 'licet', ',', 'nec', ',', 'si', 'non', 'obstatur', ',', 'propterea', 'etiam', 'permittitur.'],
                     ['Quid', 'opus', 'est', 'verbis', '?', 'lingua', 'nulla', 'est', 'qua', 'negem', 'quidquid', 'roges.'],
-                    ['Textile', 'post', 'ferrum', 'est', ',', 'quia', 'ferro', 'tela', 'paratur', ',', 'c', 'ne', 'ratione', 'alia', 'possunt', 'tam', 'levia', 'gigni', 'insilia', 'ac', 'fusi', ',', 'radii', ',', 'que', 'scapi', 'sonantes.'],
-                    ['Dic', 'si', 'audes', 'mihi', ',', 'bella', 'ne', 'videtur', 'specie', 'mulier', '?'],
-                    ['Cenavi', 'ne', 'ego', 'heri', 'in', 'navi', 'in', 'portu', 'Persico', '?']
+                    ['Textile', 'post', 'ferrum', 'est', ',', 'quia', 'ferro', 'tela', 'paratur', ',', 'nec', 'ratione', 'alia', 'possunt', 'tam', 'levia', 'gigni', 'insilia', 'ac', 'fusi', ',', 'radii', ',', 'scapi', '-que', 'sonantes.'],
+                    ['Dic', 'si', 'audes', 'mihi', ',', 'bella', '-ne', 'videtur', 'specie', 'mulier', '?'],
+                    ['Cenavi', '-ne', 'ego', 'heri', 'in', 'navi', 'in', 'portu', 'Persico', '?']
                     ]
                     
         self.assertEqual(results, target)

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -188,19 +188,23 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                 (r'quocum', 'cum quo'),
                 (r'quacum', 'cum qua'), 
                 (r'quicum', 'cum qui'),
-                (r'quibuscum', 'cum quibus')]
-
+                (r'quibuscum', 'cum quibus'),
+                (r'sodes', 'si audes'),
+                (r'satin', 'satis ne'),
+                (r'scin', 'scis ne'),
+                (r'sultis', 'si vultis'),
+                (r'similist', 'similis est'),
+                (r'qualist', 'qualis est')
+                ]
+                
         for replacement in replacements:
             string = re.sub(replacement[0], matchcase(replacement[1]), string, flags=re.IGNORECASE)
+            
+        print(string)
         
         punkt = PunktLanguageVars()
         generic_tokens = punkt.word_tokenize(string)
                     
-        # Rewrite as an if-else block for exceptions rather than separate list comprehensions
-        generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sodes' else [item[0]+'i', 'audes'])] # Handle 'sodes' as a special case.
-        generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sultis' else [item[0]+'i', 'vultis'])] # Handle 'sultis' as a special case.
-        generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'satin' else [item[:-1] + 's', 'ne'])] # Handle 'satin' as a special case.
-        generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'scin' else [item[:-1] + 's', 'ne'])] # Handle 'scin' as a special case.      
         specific_tokens = []
         for generic_token in generic_tokens:
             is_enclitic = False
@@ -213,7 +217,6 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                             if generic_token.endswith('ust'):
                                 specific_tokens += [generic_token[:-len(enclitic)+1]] + ['est']
                             else:
-                                # Does not handle 'similist', 'qualist', etc. correctly
                                 specific_tokens += [generic_token[:-len(enclitic)]] + ['est']
                         else:
                             specific_tokens += [generic_token[:-len(enclitic)]] + ['-' + enclitic]

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -31,7 +31,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
 
             self.inclusions = []
             
-            cum_inclusions = ['mecum', 'tecum', 'secum', 'nobiscum', 'vobiscum', 'quocum', 'quicum' 'quibuscum']
+            cum_inclusions = ['mecum', 'tecum', 'secum', 'nobiscum', 'vobiscum', 'quocum', 'quicum', 'quibuscum']
             
             self.exceptions = self.enclitics
 

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -180,7 +180,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
         specific_tokens = []
         for generic_token in generic_tokens:
             is_enclitic = False
-            if generic_token not in self.exceptions:
+            if generic_token.lower() not in self.exceptions:
                 for enclitic in self.enclitics:
                     if generic_token.endswith(enclitic):
                         if enclitic == 'cum':

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -189,7 +189,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                             else:
                                 specific_tokens += [generic_token]
                         elif enclitic == 'n':
-                                specific_tokens += [generic_token[:-len(enclitic)]] + ['ne']                                                                                                    
+                                specific_tokens += [generic_token[:-len(enclitic)]] + ['-ne']                                                                                                    
                         elif enclitic == 'st':
                             if generic_token.endswith('ust'):
                                 specific_tokens += [generic_token[:-len(enclitic)+1]] + ['est']
@@ -197,7 +197,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                                 # Does not handle 'similist', 'qualist', etc. correctly
                                 specific_tokens += [generic_token[:-len(enclitic)]] + ['est']
                         else:
-                            specific_tokens += [enclitic] + [generic_token[:-len(enclitic)]]
+                            specific_tokens += ['-' + enclitic] + [generic_token[:-len(enclitic)]]
                         is_enclitic = True
                         break
             if not is_enclitic:

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -7,6 +7,8 @@ Starter lists have been included to handle the Latin enclitics
  comprehensive. Additions to the exceptions list are welcome. PJB
 """
 
+import re
+
 from nltk.tokenize.punkt import PunktLanguageVars
 
 __author__ = ['Patrick J. Burns <patrick@diyclassics.org>',
@@ -27,11 +29,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                                                                                             self.available_languages)  # pylint: disable=line-too-long
 
         if self.language == 'latin':
-            self.enclitics = ['que', 'n', 'ne', 'ue', 've', 'cum','st']
-
-            self.inclusions = []
-            
-            cum_inclusions = ['mecum', 'tecum', 'secum', 'nobiscum', 'vobiscum', 'quocum', 'quicum', 'quibuscum']
+            self.enclitics = ['que', 'n', 'ne', 'ue', 've', 'st']
             
             self.exceptions = self.enclitics
 
@@ -40,7 +38,6 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
             ne_exceptions = []
             ue_exceptions = []
             ve_exceptions = []
-            cum_exceptions = []
             st_exceptions = []
 
             # quisque
@@ -165,13 +162,40 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                                        + st_exceptions
                                        ))
 
-            self.inclusions = list(set(self.inclusions
-                                       + cum_inclusions))
 
     def tokenize(self, string):
         """Tokenize incoming string."""
+        
+        def matchcase(word):
+            # From Python Cookbook
+            def replace(m):
+                text = m.group()
+                if text.isupper():
+                    return word.upper()
+                elif text.islower():
+                    return word.lower()
+                elif text[0].isupper():
+                    return word.capitalize()
+                else:
+                    return word
+            return replace
+        
+        replacements = [(r'mecum', 'cum me'),
+                (r'tecum', 'cum te'),
+                (r'secum', 'cum se'),
+                (r'nobiscum', 'cum nobis'),
+                (r'vobiscum', 'cum vobis'),
+                (r'quocum', 'cum quo'),
+                (r'quacum', 'cum qua'), 
+                (r'quicum', 'cum qui'),
+                (r'quibuscum', 'cum quibus')]
+
+        for replacement in replacements:
+            string = re.sub(replacement[0], matchcase(replacement[1]), string, flags=re.IGNORECASE)
+        
         punkt = PunktLanguageVars()
         generic_tokens = punkt.word_tokenize(string)
+                    
         # Rewrite as an if-else block for exceptions rather than separate list comprehensions
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sodes' else [item[0]+'i', 'audes'])] # Handle 'sodes' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sultis' else [item[0]+'i', 'vultis'])] # Handle 'sultis' as a special case.
@@ -183,12 +207,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
             if generic_token.lower() not in self.exceptions:
                 for enclitic in self.enclitics:
                     if generic_token.endswith(enclitic):
-                        if enclitic == 'cum':
-                            if generic_token.lower() in self.inclusions:
-                                specific_tokens += [enclitic] + [generic_token[:-len(enclitic)]]
-                            else:
-                                specific_tokens += [generic_token]
-                        elif enclitic == 'n':
+                        if enclitic == 'n':
                                 specific_tokens += [generic_token[:-len(enclitic)]] + ['-ne']                                                                                                    
                         elif enclitic == 'st':
                             if generic_token.endswith('ust'):

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -198,7 +198,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                                 # Does not handle 'similist', 'qualist', etc. correctly
                                 specific_tokens += [generic_token[:-len(enclitic)]] + ['est']
                         else:
-                            specific_tokens += ['-' + enclitic] + [generic_token[:-len(enclitic)]]
+                            specific_tokens += [generic_token[:-len(enclitic)]] + ['-' + enclitic]
                         is_enclitic = True
                         break
             if not is_enclitic:

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -198,7 +198,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                                 # Does not handle 'similist', 'qualist', etc. correctly
                                 specific_tokens += [generic_token[:-len(enclitic)]] + ['est']
                         else:
-                            specific_tokens += [generic_token[:-len(enclitic)]] + ['-' + enclitic]
+                            specific_tokens += ['-' + enclitic] + [generic_token[:-len(enclitic)]]
                         is_enclitic = True
                         break
             if not is_enclitic:

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -173,7 +173,6 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
         punkt = PunktLanguageVars()
         generic_tokens = punkt.word_tokenize(string)
         # Rewrite as an if-else block for exceptions rather than separate list comprehensions
-        generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'nec' else ['c', item[:-1]])] # Handle 'nec' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sodes' else [item[0]+'i', 'audes'])] # Handle 'sodes' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sultis' else [item[0]+'i', 'vultis'])] # Handle 'sultis' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'satin' else [item[:-1] + 's', 'ne'])] # Handle 'satin' as a special case.

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -73,7 +73,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
             que_exceptions += ['absque', 'abusque', 'adaeque', 'adusque', 'aeque', 'antique', 'atque',
                                'circumundique', 'conseque', 'cumque', 'cunque', 'denique', 'deque',
                                'donique', 'hucusque', 'inique', 'inseque', 'itaque', 'longinque',
-                               'namque', 'oblique', 'peraeque', 'praecoque', 'propinque',
+                               'namque', 'neque', 'oblique', 'peraeque', 'praecoque', 'propinque',
                                'qualiscumque', 'quandocumque', 'quandoque', 'quantuluscumque',
                                'quantumcumque', 'quantuscumque', 'quinque', 'quocumque',
                                'quomodocumque', 'quomque', 'quotacumque', 'quotcumque',
@@ -197,7 +197,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
                                 # Does not handle 'similist', 'qualist', etc. correctly
                                 specific_tokens += [generic_token[:-len(enclitic)]] + ['est']
                         else:
-                            specific_tokens += ['-' + enclitic] + [generic_token[:-len(enclitic)]]
+                            specific_tokens += [generic_token[:-len(enclitic)]] + ['-' + enclitic]
                         is_enclitic = True
                         break
             if not is_enclitic:

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -173,6 +173,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
         punkt = PunktLanguageVars()
         generic_tokens = punkt.word_tokenize(string)
         # Rewrite as an if-else block for exceptions rather than separate list comprehensions
+        generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'nec' else ['c', item[:-1]])] # Handle 'nec' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sodes' else [item[0]+'i', 'audes'])] # Handle 'sodes' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'sultis' else [item[0]+'i', 'vultis'])] # Handle 'sultis' as a special case.
         generic_tokens = [x for item in generic_tokens for x in ([item] if item.lower() != 'satin' else [item[:-1] + 's', 'ne'])] # Handle 'satin' as a special case.


### PR DESCRIPTION
Updates to the Latin tokenizer including:
- Adding hyphen before enclitics to better distinguish them from other forms
- Reverse the order of tokenized enclitics (i.e. place them after word rather than before)
- Stop tokenizing 'neque'/'nec' (see https://github.com/PerseusDL/treebank_data/issues/8)
- Better handle case in enclitic tokenization
- Fixed tokenizer test to reflect changes