### PR TITLE
Ambiguous Lemmata

### DIFF
--- a/cltk/stem/lemma.py
+++ b/cltk/stem/lemma.py
@@ -28,8 +28,8 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
         if include_ambiguous:
             lemmata_filename = '{}_lemmata_cltk.py'.format(self.language)
         else:
-            lemmata_filename = '{}_unambiguous_lemmata_ctlk.py'.format(self.language)
-        model_filename = '{}_models_ctlk.py'.format(self.language)
+            lemmata_filename = '{}_unambiguous_lemmata_cltk.py'.format(self.language)
+        model_filename = '{}_models_cltk'.format(self.language)
         module_name = '{}_lemmata_cltk'.format(self.language)
         rel_path = os.path.join('~','cltk_data',
                                 self.language,

--- a/cltk/stem/lemma.py
+++ b/cltk/stem/lemma.py
@@ -24,7 +24,9 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
         self.lemmata = self._load_replacement_patterns(include_ambiguous)
 
     def _load_replacement_patterns(self, include_ambiguous):
-        """Check for availability of lemmatizer for a language."""
+        """Check for availability of lemmatizer for a language. 
+        `include_ambiguous` specifies whether to return the most likely headword
+        for an ambiguous lemma."""
         if include_ambiguous:
             lemmata_filename = '{}_lemmata_cltk.py'.format(self.language)
         else:
@@ -46,7 +48,8 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
         """Take incoming string or list of tokens. Lookup done against a
         key-value list of lemmata-headword. If a string, tokenize with
         ``PunktLanguageVars()``. If a final period appears on a token, remove
-        it, then re-add once replacement done.
+        it, then re-add once replacement done. If `default` is given a value,
+        that value is treated as the headword for any unidentifiable lemmas.
         TODO: rm check for final period, change PunktLanguageVars() to nltk_tokenize_words()
         """
         assert type(input_text) in [list, str], \
@@ -66,31 +69,22 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
                 token = token[:-1]
 
             # look for token in lemma dict keys
-            if token.lower() in self.lemmata.keys():
+            if token in self.lemmata.keys():
+                headword = self.lemmata[token]
+            elif token.lower() in self.lemmata.keys():
                 headword = self.lemmata[token.lower()]
-
-                # re-add final period if rm'd
-                if final_period:
-                    headword += '.'
-
-                # append to return list
-                if not return_raw:
-                    lemmatized_tokens.append(headword)
-                else:
-                    lemmatized_tokens.append(token + '/' + headword)
-            # if token not found in lemma-headword list
             else:
-                # re-add final period if rm'd
-                if default is not None:
-                    return default
-                
-                if final_period:
-                    token += '.'
+                headword = token if default is None else default
 
-                if not return_raw:
-                    lemmatized_tokens.append(token)
-                else:
-                    lemmatized_tokens.append(token + '/' + token)
+            # re-add final period if rm'd
+            if final_period:
+                headword += '.'
+
+            # append to return list
+            if not return_raw:
+                lemmatized_tokens.append(headword)
+            else:
+                lemmatized_tokens.append(token + '/' + headword)
         if not return_string:
             return lemmatized_tokens
         elif return_string:

--- a/cltk/stem/lemma.py
+++ b/cltk/stem/lemma.py
@@ -42,7 +42,7 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
         lemmata = module.LEMMATA
         return lemmata
 
-    def lemmatize(self, input_text, return_raw=False, return_string=False):
+    def lemmatize(self, input_text, return_raw=False, return_string=False, default=None):
         """Take incoming string or list of tokens. Lookup done against a
         key-value list of lemmata-headword. If a string, tokenize with
         ``PunktLanguageVars()``. If a final period appears on a token, remove
@@ -81,6 +81,9 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
             # if token not found in lemma-headword list
             else:
                 # re-add final period if rm'd
+                if default is not None:
+                    return default
+                
                 if final_period:
                     token += '.'
 

--- a/cltk/stem/lemma.py
+++ b/cltk/stem/lemma.py
@@ -16,32 +16,28 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
     values from a replacement list.
     """
 
-    def __init__(self, language):
+    def __init__(self, language, include_ambiguous=True):
         """Import replacement patterns into a list."""
         self.language = language.lower()
         assert self.language in AVAILABLE_LANGUAGES, \
             "Lemmatizer not available for language '{0}'.".format(self.language)
-        self.lemmata = self._load_replacement_patterns()
+        self.lemmata = self._load_replacement_patterns(include_ambiguous)
 
-    def _load_replacement_patterns(self):
+    def _load_replacement_patterns(self, include_ambiguous):
         """Check for availability of lemmatizer for a language."""
-        if self.language == 'latin':
-            rel_path = os.path.join('~','cltk_data',
-                                    self.language,
-                                    'model','latin_models_cltk',
-                                    'lemmata','latin_lemmata_cltk.py')
-            path = os.path.expanduser(rel_path)
-            #logger.info('Loading lemmata. This may take a minute.')
-            loader = importlib.machinery.SourceFileLoader('latin_lemmata_cltk', path)
-
-        elif self.language == 'greek':
-            rel_path = os.path.join('~','cltk_data',
-                                    self.language,
-                                    'model','greek_models_cltk',
-                                    'lemmata','greek_lemmata_cltk.py')
-            path = os.path.expanduser(rel_path)
-            #logger.info('Loading lemmata. This may take a minute.')
-            loader = importlib.machinery.SourceFileLoader('greek_lemmata_cltk', path)
+        if include_ambiguous:
+            lemmata_filename = '{}_lemmata_cltk.py'.format(self.language)
+        else:
+            lemmata_filename = '{}_unambiguous_lemmata_ctlk.py'.format(self.language)
+        model_filename = '{}_models_ctlk.py'.format(self.language)
+        module_name = '{}_lemmata_cltk'.format(self.language)
+        rel_path = os.path.join('~','cltk_data',
+                                self.language,
+                                'model',model_filename,
+                                'lemmata',lemmata_filename)
+        path = os.path.expanduser(rel_path)
+        #logger.info('Loading lemmata. This may take a minute.')
+        loader = importlib.machinery.SourceFileLoader(module_name, path)
         module = loader.load_module()
         lemmata = module.LEMMATA
         return lemmata


### PR DESCRIPTION
For the project I'm working on (http://bridge.haverford.edu/), we currently use a human-review process to make sure headwords are correctly identified, so it's helpful for us to know whether a lemma was ambiguous among headwords. To that end, I added two new parameters to the lemmatizer.

In the constructor of LemmaReplacer(), there is now an `include_ambiguous` parameter (True by default) which determines whether to load lemmata from latin_lemmata_cltk.py or latin_unambiguous_lemmata_cltk.py, or the corresponding files for other languages. I'm submitting a separate pull request to the latin_pos_lemmata_cltk with an updated transform_lemmata.py file which generates a latin_unambiguous_lemmata_cltk.py file that includes only those lemmata that can be unambiguously identified. 

The second parameter is `default` in the lemmatize() method, which determines what value to use in the case that a headword is not found for a token. Currently, the token itself is returned, which makes it impossible to distinguish between the two cases of "puer" being the headword of "puer" and "cltk" having no headword at all, since the output would be "puer/puer" and "cltk/cltk" (using the `return_raw` format). In this case, if `default` is given as, for example, "NO HEADWORD FOUND", the output would be "puer/puer" and "NO HEADWORD FOUND/cltk". 

Also, this file includes a (at least temporary) fix to the problem of not returning capitalized headwords (see https://github.com/cltk/cltk/issues/307). I've tested these changes with test_stem.py and more informally on my computer, and everything seems to be in working order.