### PR TITLE
Use compiled regex to sub. More than 10x faster.

### DIFF
--- a/cltk/corpus/greek/beta_to_unicode.py
+++ b/cltk/corpus/greek/beta_to_unicode.py
@@ -388,10 +388,10 @@ class Replacer(object):  # pylint: disable=R0903
         """
         text = text.replace('-', '')
         for (pattern, repl) in self.pattern1:
-            text = regex.subn(pattern, repl, text)[0]
+            text = pattern.subn(repl, text)[0]
         for (pattern, repl) in self.pattern2:
-            text = regex.subn(pattern, repl, text)[0]
+            text = pattern.subn(repl, text)[0]
         # remove third run, if punct list not used
         for (pattern, repl) in self.pattern3:
-            text = regex.subn(pattern, repl, text)[0]
+            text = pattern.subn(repl, text)[0]
         return text


### PR DESCRIPTION
While I was working on using the betacode function to parse the Middle Liddell, I stumbled upon this speed increase.