### PR TITLE
Fix for formatting bug in Sanskrit docs

### DIFF
--- a/docs/sanskrit.rst
+++ b/docs/sanskrit.rst
@@ -14,8 +14,7 @@ Use ``CorpusImporter()`` or browse the `CLTK GitHub repository <https://github.c
 
    In [3]: c.list_corpora
    Out[3]:
-   ['sanskrit_text_jnu', 'sanskrit_text_dcs', 'sanskrit_parallel_sacred_texts', 'sanskrit_text_sacred_texts', 'sanskrit_parallel_gitasupersite', 'sanskrit_text_gitasupersite',
-'sanskrit_text_wikipedia','sanskrit_text_sanskrit_documents']
+   ['sanskrit_text_jnu', 'sanskrit_text_dcs', 'sanskrit_parallel_sacred_texts', 'sanskrit_text_sacred_texts', 'sanskrit_parallel_gitasupersite', 'sanskrit_text_gitasupersite','sanskrit_text_wikipedia','sanskrit_text_sanskrit_documents']
 
 
 Transliterator


### PR DESCRIPTION
There is a formatting bug in the Corpora section of Sanskrit docs where code is not formatted properly.This patch fixes it