### PR TITLE
Numerifier

### DIFF
--- a/cltk/corpus/punjabi/corpora.py
+++ b/cltk/corpus/punjabi/corpora.py
@@ -1,0 +1,7 @@
+PUNJABI_CORPORA = [
+    {
+    'encoding' : 'utf-8',
+    'location' : 'remote',
+    'type'     : 'text'
+    }
+]

--- a/cltk/corpus/punjabi/corpora.py
+++ b/cltk/corpus/punjabi/corpora.py
@@ -1,7 +1,0 @@
-PUNJABI_CORPORA = [
-    {
-    'encoding' : 'utf-8',
-    'location' : 'remote',
-    'type'     : 'text'
-    }
-]

--- a/cltk/corpus/punjabi/numerifier.py
+++ b/cltk/corpus/punjabi/numerifier.py
@@ -1,0 +1,26 @@
+from cltk.corpus.punjabi.alphabet import *
+def punToEnglish_number(number):
+    '''
+        Thee punToEnglish_number function will take a string num which is\
+        the number written in punjabi, like ੧੨੩, this is 123, the function\
+        will convert it to 123 and return the output as 123 of type int
+    '''
+    output = 0 #This is a simple logic, here we go to each digit and check the number and compare its index with DIGITS list in alphabet.py
+    for num in number:
+        output = 10 * output + DIGITS.index(num)
+    return output
+
+def englishToPun_number(number):
+    '''
+        This function converts the normal english number to the punjabi \
+        number with punjabi digits, its input will be an integer of type \
+        int, and output will be a string.
+    '''
+    output = ''
+    number = list(str(number))
+    for digit in number:
+        output += DIGITS[int(digit)]
+    return output
+
+if __name__ == '__main__':
+    print (englishToPun_number(123))

--- a/cltk/corpus/punjabi/numerifier.py
+++ b/cltk/corpus/punjabi/numerifier.py
@@ -1,4 +1,4 @@
-from cltk.corpus.punjabi.alphabet import *
+from cltk.corpus.punjabi.alphabet import DIGITS
 def punToEnglish_number(number):
     '''
         Thee punToEnglish_number function will take a string num which is\

--- a/cltk/corpus/utils/importer.py
+++ b/cltk/corpus/utils/importer.py
@@ -2,7 +2,6 @@
 TODO: Fix so ``import_corpora()`` can take relative path.
 TODO: Add https://github.com/cltk/pos_latin
 """
-
 from cltk.corpus.chinese.corpora import CHINESE_CORPORA
 from cltk.corpus.coptic.corpora import COPTIC_CORPORA
 from cltk.corpus.greek.corpora import GREEK_CORPORA
@@ -10,6 +9,7 @@ from cltk.corpus.latin.corpora import LATIN_CORPORA
 from cltk.corpus.sanskrit.corpora import SANSKRIT_CORPORA
 from cltk.corpus.multilingual.corpora import MULTILINGUAL_CORPORA
 from cltk.corpus.pali.corpora import PALI_CORPORA
+from cltk.corpus.punjabi.corpora import PUNJABI_CORPORA
 from cltk.corpus.tibetan.corpora import TIBETAN_CORPORA
 from cltk.utils.cltk_logger import logger
 
@@ -27,7 +27,7 @@ __author__ = ['Kyle P. Johnson <kyle@kyle-p-johnson.com>',
 __license__ = 'MIT License. See LICENSE.'
 
 
-AVAILABLE_LANGUAGES = ['chinese', 'coptic', 'greek', 'latin', 'multilingual', 'pali', 'tibetan', 'sanskrit']
+AVAILABLE_LANGUAGES = ['chinese', 'coptic', 'greek', 'latin', 'multilingual', 'pali', 'punjabi', 'tibetan', 'sanskrit']
 CLTK_DATA_DIR = '~/cltk_data'
 LANGUAGE_CORPORA = {'chinese': CHINESE_CORPORA,
                     'coptic': COPTIC_CORPORA,
@@ -35,6 +35,7 @@ LANGUAGE_CORPORA = {'chinese': CHINESE_CORPORA,
                     'latin': LATIN_CORPORA,
                     'multilingual': MULTILINGUAL_CORPORA,
                     'pali': PALI_CORPORA,
+                    'punjabi': PUNJABI_CORPORA,
                     'tibetan': TIBETAN_CORPORA,
                     'sanskrit': SANSKRIT_CORPORA,}
 

--- a/cltk/corpus/utils/importer.py
+++ b/cltk/corpus/utils/importer.py
@@ -9,7 +9,6 @@ from cltk.corpus.latin.corpora import LATIN_CORPORA
 from cltk.corpus.sanskrit.corpora import SANSKRIT_CORPORA
 from cltk.corpus.multilingual.corpora import MULTILINGUAL_CORPORA
 from cltk.corpus.pali.corpora import PALI_CORPORA
-from cltk.corpus.punjabi.corpora import PUNJABI_CORPORA
 from cltk.corpus.tibetan.corpora import TIBETAN_CORPORA
 from cltk.utils.cltk_logger import logger
 
@@ -27,7 +26,7 @@ __author__ = ['Kyle P. Johnson <kyle@kyle-p-johnson.com>',
 __license__ = 'MIT License. See LICENSE.'
 
 
-AVAILABLE_LANGUAGES = ['chinese', 'coptic', 'greek', 'latin', 'multilingual', 'pali', 'punjabi', 'tibetan', 'sanskrit']
+AVAILABLE_LANGUAGES = ['chinese', 'coptic', 'greek', 'latin', 'multilingual', 'pali',  'tibetan', 'sanskrit']
 CLTK_DATA_DIR = '~/cltk_data'
 LANGUAGE_CORPORA = {'chinese': CHINESE_CORPORA,
                     'coptic': COPTIC_CORPORA,
@@ -35,7 +34,6 @@ LANGUAGE_CORPORA = {'chinese': CHINESE_CORPORA,
                     'latin': LATIN_CORPORA,
                     'multilingual': MULTILINGUAL_CORPORA,
                     'pali': PALI_CORPORA,
-                    'punjabi': PUNJABI_CORPORA,
                     'tibetan': TIBETAN_CORPORA,
                     'sanskrit': SANSKRIT_CORPORA,}
 

--- a/cltk/tests/test_corpus.py
+++ b/cltk/tests/test_corpus.py
@@ -36,7 +36,7 @@ from cltk.corpus.sanskrit.itrans.itrans_transliterator import *
 from cltk.corpus.sanskrit.itrans.unicode_transliterate import *
 from cltk.corpus.sanskrit.itrans.langinfo import *
 from cltk.corpus.sanskrit.itrans.sinhala_transliterator import SinhalaDevanagariTransliterator  as sdt
-
+from cltk.corpus.punjabi.numerifier import *
 from unicodedata import normalize
 import os
 import unittest
@@ -602,7 +602,7 @@ class TestScriptInformation(unittest.TestCase):
 
     def test_IsRetroflex(self):
         self.assertTrue(is_retroflex('ट','hi'))
-    
+
     def test_IsDental(self):
         self.assertTrue(is_dental('त','hi'))
 
@@ -632,6 +632,14 @@ class TestScriptInformation(unittest.TestCase):
 
     def test_is_indiclang_char(self):
     	self.assertTrue(is_indiclang_char('क','hi'))
+
+class NumericalMethods(unittest.TestCase):
+    def test_punToEnglish_number(self):
+        str_test = '੧੨੩੪੫੬੭੮੯੦'
+        self.assertEqual(1234567890, punToEnglish_number(str_test))
+    def test_englishToPun_number(self):
+        str_test = '੧੨੩੪੫੬੭੮੯੦'
+        self.assertEqual(str_test, englishToPun_number(1234567890))
 
 
 if __name__ == '__main__':

--- a/cltk/tests/test_corpus.py
+++ b/cltk/tests/test_corpus.py
@@ -36,7 +36,8 @@ from cltk.corpus.sanskrit.itrans.itrans_transliterator import *
 from cltk.corpus.sanskrit.itrans.unicode_transliterate import *
 from cltk.corpus.sanskrit.itrans.langinfo import *
 from cltk.corpus.sanskrit.itrans.sinhala_transliterator import SinhalaDevanagariTransliterator  as sdt
-from cltk.corpus.punjabi.numerifier import *
+from cltk.corpus.punjabi.numerifier import punToEnglish_number
+from cltk.corpus.punjabi.numerifier import englishToPun_number
 from unicodedata import normalize
 import os
 import unittest
@@ -514,6 +515,13 @@ argenteo polubro, aureo eclutro. """
                  'stop_epoch': 'bc', 'start_epoch': 'bc'}
         self.assertEqual(_handle_splits('2/1 B.C.?'), _dict)
 
+    def test_punToEnglish_number(self):
+        str_test = '੧੨੩੪੫੬੭੮੯੦'
+        self.assertEqual(1234567890, punToEnglish_number(str_test))
+    def test_englishToPun_number(self):
+        str_test = '੧੨੩੪੫੬੭੮੯੦'
+        self.assertEqual(str_test, englishToPun_number(1234567890))
+
 
 class TestUnicode(unittest.TestCase):
     "Test py23char"
@@ -633,13 +641,6 @@ class TestScriptInformation(unittest.TestCase):
     def test_is_indiclang_char(self):
     	self.assertTrue(is_indiclang_char('क','hi'))
 
-class NumericalMethods(unittest.TestCase):
-    def test_punToEnglish_number(self):
-        str_test = '੧੨੩੪੫੬੭੮੯੦'
-        self.assertEqual(1234567890, punToEnglish_number(str_test))
-    def test_englishToPun_number(self):
-        str_test = '੧੨੩੪੫੬੭੮੯੦'
-        self.assertEqual(str_test, englishToPun_number(1234567890))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Applied suggestions, removed corpora.py, and removed its references from cltk/corpus/utils/importer.py, just undo every thing that is given in the wiki to add new corpus, changed from  `from cltk.corpus.punjabi.numerifier import * ` to `from cltk.corpus.punjabi.numerifier import <function name> ` both in test and numerifier file, removed the class NumericalMethods and added the tests to TestSequenceFunctions

Thats it may be it will be correct