### PR TITLE
Fixes #345 re: errors in Latinlibrary corpus loading methods

### DIFF
--- a/cltk/corpus/latin/__init__.py
+++ b/cltk/corpus/latin/__init__.py
@@ -9,6 +9,9 @@ CLTK Latin corpus readers
 import os.path
 from nltk.corpus.reader.plaintext import PlaintextCorpusReader
 
+from cltk.tokenize.sentence import TokenizeSentence
+from cltk.tokenize.word import WordTokenizer
+
 # Would like to have this search through a CLTK_DATA environment variable
 # Better to use something like make_cltk_path in cltk.utils.file_operations?
 home = os.path.expanduser('~')
@@ -16,7 +19,11 @@ cltk_path = os.path.join(home, 'CLTK_DATA')
 
 # Latin Library
 try:
-    latinlibrary = PlaintextCorpusReader(cltk_path + '/latin/text/latin_text_latin_library', '.*\.txt', encoding='utf-8')
+    latinlibrary = PlaintextCorpusReader(cltk_path + '/latin/text/latin_text_latin_library', 
+    '.*\.txt',
+    word_tokenizer=WordTokenizer('latin'), 
+    sent_tokenizer=TokenizeSentence('latin'), 
+    encoding='utf-8')    
     pass
 except IOError as e:
     print("Corpus not found. Please check that the Latin Library is installed in CLTK_DATA.")

--- a/cltk/tokenize/sentence.py
+++ b/cltk/tokenize/sentence.py
@@ -88,3 +88,10 @@ class TokenizeSentence():  # pylint: disable=R0903
         for sentence in tokenizer.sentences_from_text(untokenized_string, realign_boundaries=True):  # pylint: disable=C0301
             tokenized_sentences.append(sentence)
         return tokenized_sentences
+    
+    def tokenize(self: object, untokenized_string: str):
+        # NLTK's PlaintextCorpusReader needs a function called tokenize
+        # in functions used as a parameter for sentence tokenization.
+        # So this is an alias for tokenize_sentences().
+        return self.tokenize_sentences(untokenized_string)
+    

--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -125,15 +125,17 @@ def tokenize_latin_words(string):
 
     for sent in sents:
         temp_tokens = word_tokenizer.word_tokenize(sent)
-        if temp_tokens[0].endswith('ne'):
-            if temp_tokens[0].lower() not in exceptions:
-                temp = [temp_tokens[0][:-2], '-ne']
-                temp_tokens = temp + temp_tokens[1:]
+        # Need to check that tokens exist before handling them; needed to make stream.readlines work in PlaintextCorpusReader
+        if temp_tokens: 
+            if temp_tokens[0].endswith('ne'):
+                if temp_tokens[0].lower() not in exceptions:
+                    temp = [temp_tokens[0][:-2], '-ne']
+                    temp_tokens = temp + temp_tokens[1:]
 
-        if temp_tokens[-1].endswith('.'):
-            final_word = temp_tokens[-1][:-1]
-            del temp_tokens[-1]
-            temp_tokens += [final_word, '.']
+            if temp_tokens[-1].endswith('.'):
+                final_word = temp_tokens[-1][:-1]
+                del temp_tokens[-1]
+                temp_tokens += [final_word, '.']
 
         for token in temp_tokens:
             tokens.append(token)


### PR DESCRIPTION
Three updates to fix this issue:
1. PlaintextCorpusReader now uses by default the Latin-specific sentence and word tokenizers.

In turn...
2. The sentence tokenizer has been updated to include a 'tokenize' method which PlaintextCorpusReader looks for in sentence tokenizers.
3. The word tokenizer for Latin now check for empty lists before checking the list indices.