### PR TITLE
Fixes #366; fix case of cltk_data

### DIFF
--- a/cltk/corpus/latin/__init__.py
+++ b/cltk/corpus/latin/__init__.py
@@ -17,7 +17,7 @@ from cltk.tokenize.word import WordTokenizer
 # Would like to have this search through a CLTK_DATA environment variable
 # Better to use something like make_cltk_path in cltk.utils.file_operations?
 home = os.path.expanduser('~')
-cltk_path = os.path.join(home, 'CLTK_DATA')
+cltk_path = os.path.join(home, 'cltk_data')
 
 word_tokenizer = WordTokenizer('latin')
 


### PR DESCRIPTION
Working to standardize case of 'cltk_data' when loading corpora and language models so that these calls do not fail on a case-sensitive filesystems.