### PR TITLE
README: use pip3 instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The docs are at [docs.cltk.org](http://docs.cltk.org).
 CLTK supports Python version 3.5. The software only runs on POSIX–compliant operating systems (Linux, Mac OS X, FreeBSD, etc.).
 
 ``` bash
-$ pip install cltk
+$ pip3 install cltk
 ```
 
 See docs for [complete installation instructions](http://docs.cltk.org/en/latest/installation.html).


### PR DESCRIPTION
In the case of Linux-based distros, ``pip`` is the default package manager for python2.7 and ``pip3`` handles the packages for python3.x  

That's why it would be much better to use pip3 rather than pip in the installation path. 
I'm not sure how things work in MacOS

*OR* we can use this approach: 
(Source: https://docs.python.org/3.4/installing/#work-with-multiple-versions-of-python-installed-in-parallel)
... work with multiple versions of Python installed in parallel?
On Linux, Mac OS X and other POSIX systems, use the versioned Python commands in combination with the -m switch to run the appropriate copy of pip:

```
python2   -m pip install SomePackage  # default Python 2   
python2.7 -m pip install SomePackage  # specifically Python 2.7   
python3   -m pip install SomePackage  # default Python 3  
python3.4 -m pip install SomePackage  # specifically Python 3.4   
(appropriately versioned pip commands may also be available) 
```
