### PR TITLE
Update proj to py3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: python
 
 python:
-  - "3.6"
+  - "3.6" 
 
 install:
   - python setup.py sdist install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: python
 
 python:
-  - "3.5"
+  - "3.6"
 
 install:
   - python setup.py sdist install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: python
 
 python:
-  - "3.6" 
+  - "3.6"
 
 install:
   - python setup.py sdist install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The docs are at [docs.cltk.org](http://docs.cltk.org).
 
 ### Installation
 
-CLTK supports Python version 3.5. The software only runs on POSIX–compliant operating systems (Linux, Mac OS X, FreeBSD, etc.).
+CLTK supports Python version 3.6. The software only runs on POSIX–compliant operating systems (Linux, Mac OS X, FreeBSD, etc.).
 
 ``` bash
 $ pip install cltk

--- a/cltk/tests/test_utils.py
+++ b/cltk/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from collections import Counter
 import os
+from pickle import UnpicklingError
 import unittest
 
 from cltk.corpus.utils.importer import CorpusImporter
@@ -46,7 +47,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
     def test_open_pickle_fail_corrupt(self):
         """Test failure to open corrupted pickle."""
         bad_file = 'cltk/tests/bad_pickle.pickle'
-        with self.assertRaises(EOFError):
+        with self.assertRaises(UnpicklingError):
             open_pickle(bad_file)
 
     def test_logger(self):

--- a/cltk/utils/file_operations.py
+++ b/cltk/utils/file_operations.py
@@ -49,3 +49,6 @@ def open_pickle(path: str):
     except EOFError as eof_error:
         logger.error(eof_error)
         raise
+    except pickle.UnpicklingError as unp_error:
+        logger.error(unp_error)
+        raise

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,13 +8,13 @@ With Pip
 
 .. note::
 
-   The CLTK is only compatible with Python 3.5 on POSIX–compliant operating systems (Linux, Mac OS X, FreeBSD, etc.).
+   The CLTK is only officially supported with Python 3.6 on POSIX–compliant operating systems (Linux, Mac OS X, FreeBSD, etc.).
 
-First, you'll need a working installation of `Python 3.5 <https://www.python.org/downloads/>`_, which now includes Pip. Create a virtual environment and activate it as follows:
+First, you'll need a working installation of `Python 3.6 <https://www.python.org/downloads/>`_, which now includes Pip. Create a virtual environment and activate it as follows:
 
 .. code-block:: shell
 
-   $ pyvenv venv
+   $ python3.6 -m venv venv
 
    $ source venv/bin/activate
 
@@ -81,7 +81,7 @@ and download a `.tar.gz` file of the desired version. Then, you may do the follo
 
    $ tar zxvf cltk-0.1.34.tar.gz
    $ cd cltk-0.1.34
-   $ pyvenv venv
+   $ python3.6 -m venv venv
    $ source venv/bin/activate
    $ pip install -r requirements.txt
 


### PR DESCRIPTION
Note that to make a virtual env now, you must do: `python -m venv <virt_env_name>`. Docs have been update to this.