### PR TITLE
Remove python-Levenshtein dependency

### DIFF
--- a/docs/multilingual.rst
+++ b/docs/multilingual.rst
@@ -320,6 +320,10 @@ This module is under active development, so if you experience a bug or have a su
 Levenshtein distance calculation
 --------------------------------
 
+.. note::
+
+   You may optionally install `python-Levenshtein <https://pypi.python.org/pypi/python-Levenshtein>`_ as recommended by fuzzywuzzy for a 4x-10x speedup in string matching.
+
 The Levenshtein distance comparison is a commonly-used method for fuzzy string comparison.  The CLTK Levenshtein class offers a few helps for getting started with creating comparisons from document.
 
 This simple example compares a line from Vergil's Georgics with a line from Propertius (Elegies III.13.41):
@@ -339,7 +343,7 @@ Damerau-Levenshtein algorithm
 .. note::
 
    You will need to install `pyxDamerauLevenshtein <https://github.com/gfairchild/pyxDamerauLevenshtein>`_ to use these features.
-   
+
 The Damerau-Levenshtein algorithm is used for finding the distance metric between any two strings i.e., finite number of symbols or letters between any two strings. The Damerau-Levenshtein algorithm is an enhancement over Levenshtein algorithm in the sense that it allows for transposition operations.
 
 This simple example compares a two Latin words to find the distance between them:
@@ -350,7 +354,7 @@ This simple example compares a two Latin words to find the distance between them
 
    In [2]: damerau_levenshtein_distance("deaeque", "deaque")
    Out[2]: 1
-   
+
 
 
 
@@ -358,7 +362,7 @@ This simple example compares a two Latin words to find the distance between them
 Longest Common Substring
 ------------------------
 
-Longest Common Substring takes two strings as an argument to the function and returns a substring which is common between both the 
+Longest Common Substring takes two strings as an argument to the function and returns a substring which is common between both the
 strings. The example below compares a line from Vergil's Georgics with a line from Propertius (Elegies III.13.41):
 
 .. code-block:: python
@@ -376,14 +380,14 @@ The MinHash algorithm  generates a score based on the similarity of the two stri
 .. code-block:: python
 
    In [1]: from cltk.text_reuse.comparison import minhash
-   
+
    In [2]: a = 'dique deaeque omnes, studium quibus arua tueri,'
-   
+
    In [3]: b = 'dique deaeque omnes, quibus est tutela per agros,'
-   
+
    In[3]: print(minhash(a,b))
    Out[3]:0.171631205673
-   
+
 Word count
 ==========
 
@@ -531,4 +535,3 @@ If ``PunktLanguageVars`` doesn't suit your tokenization needs, consider another 
     'oris',
     'Italiam',
     'fato']
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ ptyprocess==0.5.1
 Pygments==2.1.3
 pyparsing==2.1.10
 python-dateutil==2.6.0
-python-Levenshtein==0.12.0
 pytz==2016.10
 pyuca==1.1.2
 PyYAML==3.12


### PR DESCRIPTION
python-Levenshtein is an optional dependency to the fuzzywuzzy package that provides 4x-10x speedup for string matching, but installing python-Levenshtein is causing issues for some: https://github.com/cltk/cltk/issues/508

This PR removes the python-Levenshtein and adds a note to the docs about the optional speedup by installing python-Levensthein. 

