### PR TITLE
Add line tokenizer to CLTK

### DIFF
--- a/cltk/tests/test_tokenize.py
+++ b/cltk/tests/test_tokenize.py
@@ -7,6 +7,7 @@ from cltk.corpus.utils.importer import CorpusImporter
 from cltk.tokenize.sentence import TokenizeSentence
 from cltk.tokenize.word import nltk_tokenize_words
 from cltk.tokenize.word import WordTokenizer
+from cltk.tokenize.line import LineTokenizer
 import os
 import unittest
 
@@ -28,11 +29,18 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter('latin')
-        corpus_importer.import_corpus('latin_models_cltk')
+#        corpus_importer.import_corpus('latin_models_cltk')
         file_rel = os.path.join('~/cltk_data/latin/model/latin_models_cltk/README.md')
-        file = os.path.expanduser(file_rel)
+        file = os.path.expanduser(file_rel)        
         file_exists = os.path.isfile(file)
+        if file_exists:
+            self.assertTrue(file_exists)
+        else:
+            corpus_importer.import_corpus('latin_models_cltk')
         self.assertTrue(file_exists)
+        
+
+         
 
     def test_sentence_tokenizer_latin(self):
         """Test tokenizing Latin sentences."""
@@ -124,6 +132,22 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         """Test assert error for CLTK's word tokenizer."""
         with self.assertRaises(AssertionError):
             nltk_tokenize_words(['Sentence', '1.'])
+    
+    def test_line_tokenizer(self):
+        """Test LineTokenizer"""
+        text = """49. Miraris verbis nudis me scribere versus?\nHoc brevitas fecit, sensus coniungere binos."""
+        target = ['49. Miraris verbis nudis me scribere versus?','Hoc brevitas fecit, sensus coniungere binos.']
+        tokenizer = LineTokenizer('latin')
+        tokenized_lines = tokenizer.tokenize(text)
+        self.assertTrue(tokenized_lines == target)
+
+    def test_line_tokenizer_include_blanks(self):
+        """Test LineTokenizer"""
+        text = """48. Cum tibi contigerit studio cognoscere multa,\nFac discas multa, vita nil discere velle.\n\n49. Miraris verbis nudis me scribere versus?\nHoc brevitas fecit, sensus coniungere binos."""
+        target = ['48. Cum tibi contigerit studio cognoscere multa,','Fac discas multa, vita nil discere velle.','','49. Miraris verbis nudis me scribere versus?','Hoc brevitas fecit, sensus coniungere binos.']
+        tokenizer = LineTokenizer('latin')
+        tokenized_lines = tokenizer.tokenize(text, include_blanks=True)
+        self.assertTrue(tokenized_lines == target)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cltk/tokenize/line.py
+++ b/cltk/tokenize/line.py
@@ -1,0 +1,34 @@
+"""Tokenize lines."""
+
+__author__ = 'Patrick J. Burns <patrick@diyclassics.org>'
+__license__ = 'MIT License. See LICENSE.'
+
+
+class LineTokenizer():
+    """Tokenize text by line; designed for study of poetry."""
+    
+    
+    def __init__(self, language):
+        """Lower incoming language name and assemble variables.
+        :type language: str
+        :param language : Language for sentence tokenization.
+        """
+        self.language = language.lower() # Keep in case there winds up being a need for language-specific line tokenization
+
+    def tokenize(self: object, untokenized_string: str, include_blanks=False):
+        """Tokenize lines by '\n'.
+        :type untokenized_string: str
+        :param untokenized_string: A string containing one of more sentences.
+        :param include_blanks: Boolean; If True, blanks will be preserved by "" in returned list of strings; Default is False.
+        :rtype : list of strings
+        """
+        
+        # load tokenizer
+        assert isinstance(untokenized_string, str), 'Incoming argument must be a string.'
+
+        # make list of tokenized sentences
+        if include_blanks:
+            tokenized_lines = untokenized_string.splitlines()
+        else:
+            tokenized_lines = [line for line in untokenized_string.splitlines() if line != '']
+        return tokenized_lines

--- a/docs/latin.rst
+++ b/docs/latin.rst
@@ -211,6 +211,29 @@ The backoff module also offers IdentityLemmatizer which returns the given token 
 
 NB: Documentation is still be written for the remaining backoff lemmatizers, i.e. TrainLemmatizer, ContextLemmatizer, RegexpLemmatizer, and ContextPOSLemmatizer.
 
+Line Tokenization
+=====================
+The line tokenizer takes a string input into ``tokenize()`` and returns a list of strings. 
+
+.. code-block:: python
+
+   In [1]: from cltk.tokenize.line import LineTokenizer
+
+   In [2]: tokenizer = LineTokenizer('latin')
+
+   In [3]: untokenized_text = """49. Miraris verbis nudis me scribere versus?\nHoc brevitas fecit, sensus coniungere binos."""
+
+   In [4]: tokenizer.tokenize(untokenized_text)
+   
+   Out[4]: ['49. Miraris verbis nudis me scribere versus?','Hoc brevitas fecit, sensus coniungere binos.']
+
+The line tokenizer by default removes multiple line breaks. If you wish to retain blank lines in the returned list, set the ``include_blanks`` to ``True``.
+
+   In [5]: untokenized_text = """48. Cum tibi contigerit studio cognoscere multa,\nFac discas multa, vita nil discere velle.\n\n49. Miraris verbis nudis me scribere versus?\nHoc brevitas fecit, sensus coniungere binos."""
+
+   In [6]: tokenizer.tokenize(untokenized_text, include_blanks=True)
+   
+   Out[6]: ['48. Cum tibi contigerit studio cognoscere multa,','Fac discas multa, vita nil discere velle.','','49. Miraris verbis nudis me scribere versus?','Hoc brevitas fecit, sensus coniungere binos.']
 
 Macronizer
 ==========

--- a/docs/latin.rst
+++ b/docs/latin.rst
@@ -229,6 +229,8 @@ The line tokenizer takes a string input into ``tokenize()`` and returns a list o
 
 The line tokenizer by default removes multiple line breaks. If you wish to retain blank lines in the returned list, set the ``include_blanks`` to ``True``.
 
+.. code-block:: python
+
    In [5]: untokenized_text = """48. Cum tibi contigerit studio cognoscere multa,\nFac discas multa, vita nil discere velle.\n\n49. Miraris verbis nudis me scribere versus?\nHoc brevitas fecit, sensus coniungere binos."""
 
    In [6]: tokenizer.tokenize(untokenized_text, include_blanks=True)


### PR DESCRIPTION
New line tokenizer splits texts into a list of lines. This is designed for working with poetry and is meant to be a starting point for making line-based, as opposed to grammar-based, text operations easier (e.g. studying acrostics).