### PR TITLE
add python-crfsuite

### DIFF
--- a/cltk/tests/test_tag.py
+++ b/cltk/tests/test_tag.py
@@ -93,6 +93,12 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         tagged = tagger.tag_tnt('Gallia est omnis divisa in partes tres')
         self.assertTrue(tagged)
 
+    def test_pos_crf_tagger_latin(self):
+        """Test tagging Latin POS with CRF tagger."""
+        tagger = POSTag('latin')
+        tagged = tagger.tag_crf('Gallia est omnis divisa in partes tres')
+        self.assertTrue(tagged)
+
     def test_check_latest_latin(self):
         """Test _check_latest_data()"""
         ner._check_latest_data('latin')

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     description='NLP for the ancient world',
     install_requires=['gitpython',
                       'nltk',
+                      'python-crfsuite',
                       'pyuca',
                       'pyyaml',
                       'regex',


### PR DESCRIPTION
Add `python-crfsuite` to install dependencies and add crf tagging test.