### PR TITLE
[RFC][DO NOT MERGE] Reduce duplication of dependencies in CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ before_script:
 - pip install --upgrade pip
 - pip install codecov
 - pip install coveralls
-- pip install pandas  # for the Indian syllabifier
-- pip install greek-accentuation  # for the phonetic transcriber
-- pip install fuzzywuzzy
-- pip install python-Levenshtein
-- pip install gensim  # for word2vec.py
 
 script:
   # Notes on nose:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ cycler==0.10.0
 decorator==4.0.10
 entrypoints==0.2.2
 fuzzywuzzy==0.14.0
-gensim==0.13.3
+gensim==0.13.3 # for word2vec.py
 gitdb==0.6.4
 gitdb2==2.0.0
 GitPython==2.1.1
-greek-accentuation==1.0.5
+greek-accentuation==1.0.5 # for the phonetic transcriber
 ipykernel==4.5.2
 ipython==5.1.0
 ipython-genutils==0.1.0
@@ -30,7 +30,7 @@ nbformat==4.2.0
 nltk==3.2.1
 notebook==4.3.0
 numpy==1.11.2
-pandas==0.19.1
+pandas==0.19.1 # for the Indian syllabifier
 pexpect==4.2.1
 pickleshare==0.7.4
 prompt-toolkit==1.0.9


### PR DESCRIPTION
Is it expected that by removing those 5 `pip install` calls the tests fail? I would expect `python setup.py install` to be enough. I wonder how users downloading the package from pypi can have it working, I suspect `setup.py` is incomplete.

The error I get is:
```
ERROR: Failure: ModuleNotFoundError (No module named 'greek_accentuation')
...
  File "/home/travis/build/lucafavatella/cltk/cltk/phonology/latin/transcription.py", line 17, in <module>
    from greek_accentuation import characters as chars
```

----

Please refer to commit message for details.