### PR TITLE
Old norse syllabifier

### DIFF
--- a/cltk/corpus/old_norse/syllabifier.py
+++ b/cltk/corpus/old_norse/syllabifier.py
@@ -5,7 +5,7 @@ Sonority hierarchy for Old Norse
 __author__ = ["Clément Besnier <clemsicences@aol.com>", ]
 __license__ = "MIT License"
 
-
+# Used according to sonority principle
 hierarchy = [
     ["a", "á", "æ", "e", "é", "i", "í", "o", "ǫ", "ø", "ö", "œ", "ó", "u", "ú", "y", "ý"],
     ["j"],
@@ -17,4 +17,4 @@ hierarchy = [
     ["l"]
 ]
 
-invalid_onsets = []
+# invalid_onsets = []

--- a/cltk/corpus/old_norse/syllabifier.py
+++ b/cltk/corpus/old_norse/syllabifier.py
@@ -1,0 +1,20 @@
+"""
+Sonority hierarchy for Old Norse
+"""
+
+__author__ = ["Clément Besnier <clemsicences@aol.com>", ]
+__license__ = "MIT License"
+
+
+hierarchy = [
+    ["a", "á", "æ", "e", "é", "i", "í", "o", "ǫ", "ø", "ö", "œ", "ó", "u", "ú", "y", "ý"],
+    ["j"],
+    ["m"],
+    ["n"],
+    ["p", "b", "d", "g", "t", "k"],
+    ["c", "f", "s", "h", "v", "x", "þ", "ð"],
+    ["r"],
+    ["l"]
+]
+
+invalid_onsets = []

--- a/cltk/phonology/syllabify.py
+++ b/cltk/phonology/syllabify.py
@@ -8,6 +8,8 @@ from collections import defaultdict
 from cltk.exceptions import InputError
 from cltk.corpus.middle_english.syllabifier import Syllabifier as ME_Syllabifier
 from cltk.corpus.middle_high_german.syllabifier import Syllabifier as MHG_Syllabifier
+from cltk.corpus.old_norse.syllabifier import hierarchy as OLD_NORSE_HIERARCHY
+from cltk.tokenize.word import tokenize_old_norse_words
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
@@ -66,7 +68,6 @@ def get_onsets(text, vowels="aeiou", threshold=0.0002):
 
 
 class Syllabifier:
-
     def __init__(self, low_vowels=None, mid_vowels=None, high_vowels=None, flaps=None, laterals=None, nasals=None,
                  fricatives=None, plosives=None, language=None):
         
@@ -78,8 +79,7 @@ class Syllabifier:
 
             self.set_hierarchy(hierarchy)
             self.set_vowels(hierarchy[0])
-        
-        
+
         elif language == 'middle high german':
             hierarchy = [[] for _ in range(len(set(MHG_Syllabifier.values())))]
 
@@ -88,6 +88,10 @@ class Syllabifier:
 
             self.set_hierarchy(hierarchy)
             self.set_vowels(hierarchy[0])
+
+        elif language == "old_norse":
+            self.set_hierarchy(OLD_NORSE_HIERARCHY)
+            self.set_vowels(OLD_NORSE_HIERARCHY[0])
 
         else:
 
@@ -258,7 +262,6 @@ class Syllabifier:
 
         return self.onset_maximization(word)
 
-    
     def onset_maximization(self, syllables):
 
         for i, syl in enumerate(syllables):
@@ -268,8 +271,7 @@ class Syllabifier:
                     syllables[i] = syllables[i][:-1]
 
         return syllables
-    
-    
+
     def legal_onsets(self, syllables, invalid_onsets):
         """
         Filters syllable respecting the legality principle
@@ -296,7 +298,7 @@ class Syllabifier:
                 onset += letter
 
             for j in range(len(onset)):
-                #Check whether the given onset is valid
+                # Check whether the given onset is valid
                 if onset[j:] not in invalid_onsets:
                     syllables[i - 1] += onset[:j]
                     syllables[i] = syllables[i][j:]
@@ -316,3 +318,12 @@ class Syllabifier:
         print(word)
         return self.syllabify_SSP(word)
 
+
+if __name__ == "__main__":
+    s = Syllabifier(language="old_norse")
+    text = "Gefjun dró frá Gylfa glöð djúpröðul óðla, svá at af rennirauknum rauk, Danmarkar auka. Báru öxn ok átta" \
+           " ennitungl, þars gengu fyrir vineyjar víðri valrauf, fjögur höfuð."
+    l = tokenize_old_norse_words(text)
+    for word in l:
+        if word not in ",.":
+            print(s.legal_onsets(s.syllabify_SSP(word.lower()), ['lm', "fj", "nm", "rk", "nn", "tt", "ðr"]))

--- a/cltk/phonology/syllabify.py
+++ b/cltk/phonology/syllabify.py
@@ -317,13 +317,3 @@ class Syllabifier:
 
         print(word)
         return self.syllabify_SSP(word)
-
-
-if __name__ == "__main__":
-    s = Syllabifier(language="old_norse")
-    text = "Gefjun dró frá Gylfa glöð djúpröðul óðla, svá at af rennirauknum rauk, Danmarkar auka. Báru öxn ok átta" \
-           " ennitungl, þars gengu fyrir vineyjar víðri valrauf, fjögur höfuð."
-    l = tokenize_old_norse_words(text)
-    for word in l:
-        if word not in ",.":
-            print(s.legal_onsets(s.syllabify_SSP(word.lower()), ['lm', "fj", "nm", "rk", "nn", "tt", "ðr"]))

--- a/cltk/tests/test_phonology.py
+++ b/cltk/tests/test_phonology.py
@@ -14,6 +14,8 @@ from cltk.phonology.old_norse import transcription as ont
 from cltk.phonology.gothic import transcription as gothic
 from cltk.phonology.old_swedish import transcription as old_swedish
 from cltk.phonology import utils as ut
+from cltk.phonology.syllabify import Syllabifier
+from cltk.tokenize.word import tokenize_old_norse_words
 import unittest
 
 
@@ -506,7 +508,7 @@ class TestSequenceFunctions(unittest.TestCase):
         transcribed_sentence = tr.main(sentence)
         self.assertEqual("[far man kunu ok dør han før ɛn hun far barn ok siɣɛr hun ok hɛnːɛ frɛndɛr]",
                          transcribed_sentence)
-        
+
     def test_utils(self):
         # definition of a Vowel
         a = ut.Vowel("open", "front", False, "short", "a")
@@ -731,6 +733,20 @@ class TestSequenceFunctions(unittest.TestCase):
 
         # pattern3 = ru3.ipa_to_regular_expression(PHONOLOGY)
         # print(ut.Rule.from_regular_expression(pattern3, ru3.temp_sound.ipar, IPA_class))
+
+    def test_syllabification_old_norse(self):
+        s = Syllabifier(language="old_norse")
+        text = "Gefjun dró frá Gylfa glöð djúpröðul óðla, svá at af rennirauknum rauk, Danmarkar auka. Báru öxn ok átta" \
+               " ennitungl, þars gengu fyrir vineyjar víðri valrauf, fjögur höfuð."
+        words = tokenize_old_norse_words(text)
+        syllabified_words = [s.legal_onsets(s.syllabify_SSP(word.lower()), ['lm', "fj", "nm", "rk", "nn", "tt", "ðr"])
+                             for word in words if word not in ",."]
+        # Not all syllabifications are correct
+        target = [['gef', 'jun'], ['dró'], ['frá'], ['gyl', 'fa'], ['glöð'], ['djúp', 'rö', 'ðul'], ['óðl', 'a'],
+                  ['svá'], ['at'], ['af'], ['renni', 'rauk', 'num'], ['rauk'], ['dan', 'mar', 'kar'], ['auk', 'a'],
+                  ['bár', 'u'], ['öxn'], ['ok'], ['átta'], ['enni', 'tungl'], ['þars'], ['geng', 'u'],  ['fy', 'rir'],
+                  ['vi', 'ney', 'jar'], ['víðr', 'i'], ['val', 'rauf'], ['fjö', 'gur'], ['hö', 'fuð']]
+        self.assertListEqual(syllabified_words, target)
 
 
 if __name__ == '__main__':

--- a/docs/old_norse.rst
+++ b/docs/old_norse.rst
@@ -144,3 +144,17 @@ The oldest runic inscriptions found are from 200 AC. They have always denoted Ge
 
     Out [4]: "᛫kurmR᛫kunukR᛫k(ar)þi᛫kubl᛫þusi᛫a(ft)᛫þurui᛫kunu᛫sina᛫tanmarkaR᛫but᛫"
 
+Syllabification
+===============
+
+For a language-dependent approach, you can call the predefined sonority dictionary by toogling the ``language`` parameter:
+
+.. code-block:: python
+
+   In [1]: s = Syllabifier(language='old_norse')
+
+   In [2]: s.syllabify("danmarkar")
+
+   Out[2]: ['dan', 'mar', 'kar']
+
+


### PR DESCRIPTION
Here is a suggestion for the Old Norse syllabifier. I used the syllabifier made by @Sedictious.

As shown in the test, You can see below the current results computed:

```python
s = Syllabifier(language="old_norse")
text = "Gefjun dró frá Gylfa glöð djúpröðul óðla, svá at af rennirauknum rauk, Danmarkar auka. Báru öxn ok átta ennitungl, þars gengu fyrir vineyjar víðri valrauf, fjögur höfuð."
syllabified_words = [s.legal_onsets(s.syllabify_SSP(word.lower()), ['lm', "fj", "nm", "rk", "nn", "tt", "ðr"])
syllabified_words
[['gef', 'jun'], ['dró'], ['frá'], ['gyl', 'fa'], ['glöð'], ['djúp', 'rö', 'ðul'], ['óðl', 'a'],
['svá'], ['at'], ['af'], ['renni', 'rauk', 'num'], ['rauk'], ['dan', 'mar', 'kar'], ['auk', 'a'],
['bár', 'u'], ['öxn'], ['ok'], ['átta'], ['enni', 'tungl'], ['þars'], ['geng', 'u'],  ['fy', 'rir'],
['vi', 'ney', 'jar'], ['víðr', 'i'], ['val', 'rauf'], ['fjö', 'gur'], ['hö', 'fuð']]
```
I don't know how to give better parameters so that I get  ['en', 'ni', 'tungl']  instead of ['enni', 'tungl'] and ['átta'] instead of ['át', 'ta']. Do you have ideas @Sedictious?