### PR TITLE
Update requirements.txt for Python 3.7 and out-of-box test success

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -107,10 +107,11 @@ The `CLTK source is available at GitHub <https://github.com/cltk/cltk>`_. To bui
 
 .. code-block:: shell
 
+   $ pip install -U -r requirements.txt 
    $ python setup.py install
 
-If you have modified the CLTK source, rebuild the project with this same command. If you make any changes, it is a good idea to run the test suite to ensure you did not introduce any breakage. Test with ``nose`` (obtained with ``pip install nose``):
+If you have modified the CLTK source, rebuild the project with this same command. If you make any changes, it is a good idea to run the test suite to ensure you did not introduce any breakage. Test with ``nose``:
 
 .. code-block:: shell
 
-   $ nosetests
+   $ nosetests --with-doctest

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ ptyprocess==0.6.0
 Pygments==2.2.0
 pylint==1.9.2
 pyparsing==2.2.0
-python-crfsuite==0.9.5
+python-crfsuite==0.9.6
 python-dateutil==2.7.3
 pyuca==1.2
 PyYAML==3.13
@@ -80,3 +80,10 @@ webencodings==0.5.1
 Whoosh==2.7.4
 widgetsnbextension==3.2.1
 wrapt==1.10.11
+nose==1.3.7
+scikit-learn==0.19.2
+fuzzywuzzy==0.17.0
+python-Levenshtein==0.12.0
+pandas==0.23.4
+greek-accentuation==1.2.0
+


### PR DESCRIPTION
This refers also to #792 

A newer point release in the Python CRF suite builds correctly, so 3.7 should now be usable.
While at it, I added to `requirements.txt` modules that are needed to successfully run the unit tests.

The documentation for installation from source is updated to reflect the sequence that enables tests to pass without manually installing dependencies.

Tested on Mac OS X and Win 10+Linux subsystem.

Question: why does my fork show that I'm a load of commits ahead of upstream, even though my latest was merged?