### PR TITLE
update travis to use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 sudo: required
 
+dist: xenial
+
 language: python
 
 python:
 - '3.6'
+- '3.7'
 
 before_install:
 - sudo rm -f /etc/boto.cfg


### PR DESCRIPTION
> 3.7 not available on default Ubuntu/travis builds, so using
instructions here: https://docs.travis-ci.com/user/languages/python/ to
update us to 3.7 (while keeping 3.6) and maybe later pre-release dev
builds