### PR TITLE
Update corpus files to include Tesserae corpora

### DIFF
--- a/cltk/corpus/latin/corpora.py
+++ b/cltk/corpus/latin/corpora.py
@@ -85,5 +85,11 @@ LATIN_CORPORA = [
     {'location': 'remote',
      'type': 'text',
      'name': 'latin_text_poeti_ditalia',
-     'origin': 'https://github.com/cltk/latin_text_poeti_ditalia.git'}
+     'origin': 'https://github.com/cltk/latin_text_poeti_ditalia.git'},
+    {'name': 'latin_text_tesserae',
+     'encoding': 'utf-8',
+     'markup': 'plaintext', #modified plaintext with Tesserae-style citations
+     'origin': 'https://github.com/cltk/greek_text_tesserae.git',
+     'location': 'remote',
+     'type': 'text'},
 ]

--- a/cltk/corpus/latin/corpora.py
+++ b/cltk/corpus/latin/corpora.py
@@ -89,7 +89,7 @@ LATIN_CORPORA = [
     {'name': 'latin_text_tesserae',
      'encoding': 'utf-8',
      'markup': 'plaintext', #modified plaintext with Tesserae-style citations
-     'origin': 'https://github.com/cltk/greek_text_tesserae.git',
+     'origin': 'https://github.com/cltk/latin_text_tesserae.git',
      'location': 'remote',
      'type': 'text'},
 ]

--- a/cltk/corpus/readers.py
+++ b/cltk/corpus/readers.py
@@ -23,9 +23,13 @@ LOG.addHandler(logging.NullHandler())
 
 # TODO add your corpus here:
 SUPPORTED_CORPORA = {
-    'latin': ['latin_text_latin_library', 'latin_text_perseus'],
+    'latin': ['latin_text_latin_library',
+              'latin_text_perseus',
+              'latin_text_tesserae',
+              ],
     'greek': ['greek_text_perseus',
-              'greek_text_tesserae']
+              'greek_text_tesserae',
+              ]
 }  # type: Dict[str, List[str]]
 
 

--- a/cltk/corpus/readers.py
+++ b/cltk/corpus/readers.py
@@ -23,13 +23,9 @@ LOG.addHandler(logging.NullHandler())
 
 # TODO add your corpus here:
 SUPPORTED_CORPORA = {
-    'latin': ['latin_text_latin_library',
-              'latin_text_perseus',
-              'latin_text_tesserae',
-              ],
+    'latin': ['latin_text_latin_library', 'latin_text_perseus'],
     'greek': ['greek_text_perseus',
-              'greek_text_tesserae',
-              ]
+              'greek_text_tesserae']
 }  # type: Dict[str, List[str]]
 
 
@@ -65,6 +61,12 @@ def get_corpus_reader(corpus_name: str = None, language: str = None) -> CorpusRe
                                         sent_tokenizer=sentence_tokenizer,
                                         word_tokenizer=the_word_tokenizer,
                                         target_language='latin')  # perseus also contains English
+
+        if corpus_name == 'latin_text_tesserae':
+            return TesseraeCorpusReader(root=root, fileids=r'.*\.tess',
+                                                 sent_tokenizer=sentence_tokenizer,
+                                                 word_tokenizer=the_word_tokenizer,
+                                                 )
 
     if language == 'greek':
         if corpus_name == 'greek_text_perseus':


### PR DESCRIPTION
CLTK Tesserae Ancient Greek Corpus & CLTK Tesserae Latin Corpus are now available in the CLTK GitHub repository (e.g. https://github.com/cltk/greek_text_tesserae). This PR makes the files (Latin specifically; Greek was in a previous PR) available to the corpus installer and the plaintext reader.