### PR TITLE
Use a global function to determine the CLTK data directory

### DIFF
--- a/cltk/__init__.py
+++ b/cltk/__init__.py
@@ -21,14 +21,11 @@ __url__ = 'http://cltk.org'
 
 __version__ = get_distribution('cltk').version  # pylint: disable=no-member
 
-# ADDED: almostearthling 20190601
-# provide a built-in variable containing the CLTK data directory instead of
-# using the default, cluttering and venv-fairly-incompatible ~/cltk_data: if
-# an environment variable named CLTK_DATA is available, use it to determine
-# where data have to be stored, otherwise fall back to the old solution and
-# use ~/cltk_data as usual; when a Python Virtual Environment is used the
-# CLTK_DATA variable can be set in the activation script
-if 'CLTK_DATA' in os.environ:
+
+# retrieve the data directory from environment, fall back if not found
+# WARNING: skip coverage test on unreachable branch (tip: change test
+# script to run tests with a defined CLTK_DATA environment variable)
+if 'CLTK_DATA' in os.environ:   # pragma: no cover
     __cltk_data_dir__ = os.path.expanduser(
         os.path.normpath(os.environ['CLTK_DATA']))
 else:
@@ -36,7 +33,7 @@ else:
         os.path.normpath("~/cltk_data"))
 
 
-# return the data directory instead of giving access to the variable directly
+# return the data directory instead of providing direct access to the variable
 def get_cltk_data_dir():
     return __cltk_data_dir__
 

--- a/cltk/__init__.py
+++ b/cltk/__init__.py
@@ -4,6 +4,8 @@ more information and documentation: http://cltk.org
 """
 
 import sys
+import os
+import builtins
 from pkg_resources import get_distribution
 
 if sys.version_info[0] != 3:
@@ -19,6 +21,30 @@ __url__ = 'http://cltk.org'
 
 __version__ = get_distribution('cltk').version  # pylint: disable=no-member
 
+# ADDED: almostearthling 20190601
+# provide a built-in variable containing the CLTK data directory instead of
+# using the default, cluttering and venv-fairly-incompatible ~/cltk_data: if
+# an environment variable named CLTK_DATA is available, use it to determine
+# where data have to be stored, otherwise fall back to the old solution and
+# use ~/cltk_data as usual; when a Python Virtual Environment is used the
+# CLTK_DATA variable can be set in the activation script
+if 'CLTK_DATA' in os.environ:
+    __cltk_data_dir__ = os.path.expanduser(
+        os.path.normpath(os.environ['CLTK_DATA']))
+else:
+    __cltk_data_dir__ = os.path.expanduser(
+        os.path.normpath("~/cltk_data"))
+
+
+# return the data directory instead of giving access to the variable directly
+def get_cltk_data_dir():
+    return __cltk_data_dir__
+
+
+builtins.get_cltk_data_dir = get_cltk_data_dir
+
 # rm these namespaces from memory, or these show up in dir(cltk)
 del get_distribution
+del builtins
+del os
 del sys

--- a/cltk/__init__.py
+++ b/cltk/__init__.py
@@ -21,20 +21,29 @@ __url__ = 'http://cltk.org'
 
 __version__ = get_distribution('cltk').version  # pylint: disable=no-member
 
-
-# retrieve the data directory from environment, fall back if not found
-# WARNING: skip coverage test on unreachable branch (tip: change test
-# script to run tests with a defined CLTK_DATA environment variable)
 if 'CLTK_DATA' in os.environ:   # pragma: no cover
     __cltk_data_dir__ = os.path.expanduser(
         os.path.normpath(os.environ['CLTK_DATA']))
+    if not os.path.isdir(__cltk_data_dir__):
+        raise FileNotFoundError('Custom data directory `%s` does not exist. '
+                                'Update your OS environment variable `$CLTK_DATA` '
+                                'or remove it.' % __cltk_data_dir__)
+    if not os.access(__cltk_data_dir__, os.W_OK):
+        raise PermissionError('Custom data directory `%s` must have '
+                              'write permission.' % __cltk_data_dir__)
 else:
     __cltk_data_dir__ = os.path.expanduser(
-        os.path.normpath("~/cltk_data"))
+        os.path.normpath('~/cltk_data'))
 
 
-# return the data directory instead of providing direct access to the variable
-def get_cltk_data_dir():
+def get_cltk_data_dir() -> str:
+    """Defines where to look for the `cltk_data` dir. By default, this is located
+     in a user's home directory and the directory is created there (`~/cltk_data`).
+     However a user may customize where this goes with the OS environment variable
+     `$CLTK_DATA`. If the variable is found, then its value is used.
+
+    TODO: Run tests with a defined `$CLTK_DATA` environment variable)
+    """
     return __cltk_data_dir__
 
 

--- a/cltk/corpus/greek/tei.py
+++ b/cltk/corpus/greek/tei.py
@@ -26,7 +26,7 @@ def onekgreek_tei_xml_to_text():
     if not bs4_installed:
         logger.error('Install `bs4` and `lxml` to parse these TEI files.')
         raise ImportError
-    xml_dir = os.path.expanduser('~/cltk_data/greek/text/greek_text_first1kgreek/data/*/*/*.xml')
+    xml_dir = os.path.normpath(get_cltk_data_dir() + '/greek/text/greek_text_first1kgreek/data/*/*/*.xml')
     xml_paths = glob.glob(xml_dir)
     if not len(xml_paths):
         logger.error('1K Greek corpus not installed. Use CorpusInstaller to get `First1KGreek`.')
@@ -34,7 +34,7 @@ def onekgreek_tei_xml_to_text():
     xml_paths = [path for path in xml_paths if '__cts__' not in path]
 
     # new dir
-    new_dir = os.path.expanduser('~/cltk_data/greek/text/greek_text_first1kgreek_plaintext/')
+    new_dir = os.path.normpath(get_cltk_data_dir() + '/greek/text/greek_text_first1kgreek_plaintext/')
     if not os.path.isdir(new_dir):
         os.makedirs(new_dir)
 
@@ -54,8 +54,8 @@ def onekgreek_tei_xml_to_text():
 def onekgreek_tei_xml_to_text_capitains():
     """Use MyCapitains program to convert TEI to plaintext."""
     file = os.path.expanduser(
-        '~/cltk_data/greek/text/greek_text_first1kgreek/data/tlg0627/tlg021/tlg0627.tlg021.1st1K-grc1.xml')
-    xml_dir = os.path.expanduser('~/cltk_data/greek/text/greek_text_first1kgreek/data/*/*/*.xml')
+        get_cltk_data_dir() + '/greek/text/greek_text_first1kgreek/data/tlg0627/tlg021/tlg0627.tlg021.1st1K-grc1.xml')
+    xml_dir = os.path.normpath(get_cltk_data_dir() + '/greek/text/greek_text_first1kgreek/data/*/*/*.xml')
     xml_paths = glob.glob(xml_dir)
     if not len(xml_paths):
         logger.error('1K Greek corpus not installed. Use CorpusInstaller to get `First1KGreek`.')
@@ -63,7 +63,7 @@ def onekgreek_tei_xml_to_text_capitains():
     xml_paths = [path for path in xml_paths if '__cts__' not in path]
 
     # new dir
-    new_dir = os.path.expanduser('~/cltk_data/greek/text/greek_text_first1kgreek_plaintext/')
+    new_dir = os.path.normpath(get_cltk_data_dir() + '/greek/text/greek_text_first1kgreek_plaintext/')
     if not os.path.isdir(new_dir):
         os.makedirs(new_dir)
 

--- a/cltk/corpus/greek/tlgu.py
+++ b/cltk/corpus/greek/tlgu.py
@@ -47,7 +47,7 @@ class TLGU(object):
     @staticmethod
     def _check_import_source():
         """Check if tlgu imported, if not import it."""
-        path_rel = '~/cltk_data/greek/software/greek_software_tlgu/tlgu.h'
+        path_rel = get_cltk_data_dir() + '/greek/software/greek_software_tlgu/tlgu.h'
         path = os.path.expanduser(path_rel)
         if not os.path.isfile(path):
             try:
@@ -67,7 +67,7 @@ class TLGU(object):
             if not subprocess.check_output(['which', 'gcc']):
                 logger.error('GCC seems not to be installed.')
             else:
-                tlgu_path_rel = '~/cltk_data/greek/software/greek_software_tlgu'
+                tlgu_path_rel = get_cltk_data_dir() + '/greek/software/greek_software_tlgu'
                 tlgu_path = os.path.expanduser(tlgu_path_rel)
                 if not self.testing:
                     print('Do you want to install TLGU?')
@@ -181,9 +181,9 @@ class TLGU(object):
         TODO: Add markup options to input.
         TODO: Do something with break_lines, divide_works, and extra_args or rm them
         """
-        orig_path_rel = '~/cltk_data/originals'
+        orig_path_rel = get_cltk_data_dir() + '/originals'
         orig_path = os.path.expanduser(orig_path_rel)
-        target_path_rel = '~/cltk_data'
+        target_path_rel = get_cltk_data_dir()
         target_path = os.path.expanduser(target_path_rel)
         assert corpus in ['tlg', 'phi5', 'phi7'], "Corpus must be 'tlg', 'phi5', or 'phi7'"
         if corpus in ['tlg', 'phi5', 'phi7']:
@@ -229,13 +229,13 @@ class TLGU(object):
         TODO: Write test for this
         """
         if corpus == 'tlg':
-            orig_dir_rel = '~/cltk_data/originals/tlg'
-            works_dir_rel = '~/cltk_data/greek/text/tlg/individual_works'
+            orig_dir_rel = get_cltk_data_dir() + '/originals/tlg'
+            works_dir_rel = get_cltk_data_dir() + '/greek/text/tlg/individual_works'
             file_prefix = 'TLG'
             latin = False
         elif corpus == 'phi5':
-            orig_dir_rel = '~/cltk_data/originals/phi5'
-            works_dir_rel = '~/cltk_data/latin/text/phi5/individual_works'
+            orig_dir_rel = get_cltk_data_dir() + '/originals/phi5'
+            works_dir_rel = get_cltk_data_dir() + '/latin/text/phi5/individual_works'
             file_prefix = 'LAT'
             latin = True  # this is for the optional TLGU argument to convert()
 

--- a/cltk/corpus/readers.py
+++ b/cltk/corpus/readers.py
@@ -40,7 +40,7 @@ def get_corpus_reader(corpus_name: str = None, language: str = None) -> CorpusRe
     :param langugage: the language for search in
     :return: NLTK compatible corpus reader
     """
-    BASE = '~/cltk_data/{}/text'.format(language)
+    BASE = get_cltk_data_dir() + '/{}/text'.format(language)
     root = os.path.join(os.path.expanduser(BASE), corpus_name)
 
     if not os.path.exists(root) or corpus_name not in SUPPORTED_CORPORA.get(language):

--- a/cltk/corpus/utils/formatter.py
+++ b/cltk/corpus/utils/formatter.py
@@ -164,7 +164,7 @@ def phi5_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False):
 
 def assemble_tlg_author_filepaths():
     """Reads TLG index and builds a list of absolute filepaths."""
-    plaintext_dir_rel = '~/cltk_data/greek/text/tlg/plaintext/'
+    plaintext_dir_rel = get_cltk_data_dir() + '/greek/text/tlg/plaintext/'
     plaintext_dir = os.path.expanduser(plaintext_dir_rel)
     filepaths = [os.path.join(plaintext_dir, x + '.TXT') for x in TLG_INDEX]
     return filepaths
@@ -173,7 +173,7 @@ def assemble_tlg_author_filepaths():
 def assemble_phi5_author_filepaths():
     """Reads PHI5 index and builds a list of absolute filepaths.
     """
-    plaintext_dir_rel = '~/cltk_data/latin/text/phi5/plaintext/'
+    plaintext_dir_rel = get_cltk_data_dir() + '/latin/text/phi5/plaintext/'
     plaintext_dir = os.path.expanduser(plaintext_dir_rel)
     filepaths = [os.path.join(plaintext_dir, x + '.TXT') for x in PHI5_INDEX]
     return filepaths
@@ -181,7 +181,7 @@ def assemble_phi5_author_filepaths():
 
 def assemble_tlg_works_filepaths():
     """Reads TLG index and builds a list of absolute filepaths."""
-    plaintext_dir_rel = '~/cltk_data/greek/text/tlg/individual_works/'
+    plaintext_dir_rel = get_cltk_data_dir() + '/greek/text/tlg/individual_works/'
     plaintext_dir = os.path.expanduser(plaintext_dir_rel)
     all_filepaths = []
     for author_code in TLG_WORKS_INDEX:
@@ -195,7 +195,7 @@ def assemble_tlg_works_filepaths():
 
 def assemble_phi5_works_filepaths():
     """Reads PHI5 index and builds a list of absolute filepaths."""
-    plaintext_dir_rel = '~/cltk_data/latin/text/phi5/individual_works/'
+    plaintext_dir_rel = get_cltk_data_dir() + '/latin/text/phi5/individual_works/'
     plaintext_dir = os.path.expanduser(plaintext_dir_rel)
     all_filepaths = []
     for author_code in PHI5_WORKS_INDEX:

--- a/cltk/corpus/utils/importer.py
+++ b/cltk/corpus/utils/importer.py
@@ -52,7 +52,7 @@ AVAILABLE_LANGUAGES = ['akkadian', 'arabic', 'chinese', 'coptic', 'greek', 'hebr
                        'french', 'gujarati', 'middle_high_german', 'middle_low_german']
 
 
-CLTK_DATA_DIR = '~/cltk_data'
+CLTK_DATA_DIR = get_cltk_data_dir()
 LANGUAGE_CORPORA = {'akkadian': AKKADIAN_CORPORA,
                     'arabic': ARABIC_CORPORA,
                     'chinese': CHINESE_CORPORA,
@@ -141,15 +141,15 @@ class CorpusImporter:
         return 'CorpusImporter for: {}'.format(self.language)
 
     def _check_distributed_corpora_file(self):
-        """Check '~/cltk_data/distributed_corpora.yaml' for any custom,
+        """Check get_cltk_data_dir() + '/distributed_corpora.yaml' for any custom,
         distributed corpora that the user wants to load locally.
 
         TODO: write check or try if `cltk_data` dir is not present
         """
         if self.testing:
-            distributed_corpora_fp = os.path.expanduser('~/cltk_data/test_distributed_corpora.yaml')
+            distributed_corpora_fp = os.path.normpath(get_cltk_data_dir() + '/test_distributed_corpora.yaml')
         else:
-            distributed_corpora_fp = os.path.expanduser('~/cltk_data/distributed_corpora.yaml')
+            distributed_corpora_fp = os.path.normpath(get_cltk_data_dir() + '/distributed_corpora.yaml')
 
         try:
             with open(distributed_corpora_fp) as file_open:

--- a/cltk/ir/boolean.py
+++ b/cltk/ir/boolean.py
@@ -28,7 +28,7 @@ class CLTKIndex:
         chunks = ['author', 'work']
         assert self.chunk in chunks, 'Chunk must be one of the following: {}.'.format(chunks)
 
-        self.index_dir_base = os.path.expanduser('~/cltk_data')
+        self.index_dir_base = get_cltk_data_dir()
         self.index_dir_base = os.path.join(self.index_dir_base, lang, 'index')
         self.index_path = os.path.join(self.index_dir_base, corpus, chunk)
 
@@ -68,13 +68,13 @@ class CLTKIndex:
 
         # Setup corpus to be indexed
         if self.lang == 'greek' and self.corpus == 'tlg':
-            corpus_path = os.path.expanduser('~/cltk_data/greek/text/tlg/plaintext/')
+            corpus_path = os.path.normpath(get_cltk_data_dir() + '/greek/text/tlg/plaintext/')
             if self.chunk == 'work':
-                corpus_path = os.path.expanduser('~/cltk_data/greek/text/tlg/individual_works/')
+                corpus_path = os.path.normpath(get_cltk_data_dir() + '/greek/text/tlg/individual_works/')
         elif self.lang == 'latin' and self.corpus == 'phi5':
-            corpus_path = os.path.expanduser('~/cltk_data/latin/text/phi5/plaintext/')
+            corpus_path = os.path.normpath(get_cltk_data_dir() + '/latin/text/phi5/plaintext/')
             if self.chunk == 'work':
-                corpus_path = os.path.expanduser('~/cltk_data/latin/text/phi5/individual_works/')
+                corpus_path = os.path.normpath(get_cltk_data_dir() + '/latin/text/phi5/individual_works/')
         assert os.path.isdir(corpus_path), 'Corpus does not exist in the following location: "%s". Use CLTK Corpus Importer and TLGU to create transformed corpus.' % corpus_path  # pylint: disable=line-too-long
 
         files = os.listdir(corpus_path)
@@ -189,7 +189,7 @@ class CLTKIndex:
                 output_str += lines_br + '</br></br>'
 
         if save_file:
-            user_dir = os.path.expanduser('~/cltk_data/user_data/search')
+            user_dir = os.path.normpath(get_cltk_data_dir() + '/user_data/search')
             output_path = os.path.join(user_dir, save_file + '.html')
 
             try:
@@ -213,7 +213,7 @@ if __name__ == '__main__':
     #_results = cltk_index.corpus_query('ἀνὴρ')
     #print(_results)
 
-    user_dir = os.path.expanduser('~/cltk_data/user_data/search')
+    user_dir = os.path.normpath(get_cltk_data_dir() + '/user_data/search')
     output_file = 'amicitia.html'
     output_path = os.path.join(user_dir, output_file)
 

--- a/cltk/lemmatize/french/lemma.py
+++ b/cltk/lemmatize/french/lemma.py
@@ -19,7 +19,7 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
     def _load_entries(self):
         """Check for availability of lemmatizer for French."""
 
-        rel_path = os.path.join('~','cltk_data',
+        rel_path = os.path.join(get_cltk_data_dir(),
                                 'french',
                                 'text','french_data_cltk'
                                 ,'entries.py')
@@ -32,7 +32,7 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
 
     def _load_forms_and_lemmas(self):
 
-        rel_path = os.path.join('~', 'cltk_data',
+        rel_path = os.path.join(get_cltk_data_dir(),
                                 'french',
                                 'text', 'french_data_cltk',
                                 'forms_and_lemmas.py')
@@ -72,4 +72,3 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
                         lemmed = (token, "None")
                         lemmatized.append(lemmed)
         return lemmatized
-

--- a/cltk/lemmatize/greek/backoff.py
+++ b/cltk/lemmatize/greek/backoff.py
@@ -18,7 +18,7 @@ class BackoffGreekLemmatizer(object):
     type of major sequential backoff class from backoff.py
     """
 
-    models_path = os.path.expanduser('~/cltk_data/greek/model/greek_models_cltk/lemmata/backoff')
+    models_path = os.path.normpath(get_cltk_data_dir() + '/greek/model/greek_models_cltk/lemmata/backoff')
 
     def __init__(self: object, train: List[list] = None, seed: int = 3, verbose: bool = False):
         self.models_path = BackoffGreekLemmatizer.models_path

--- a/cltk/lemmatize/latin/backoff.py
+++ b/cltk/lemmatize/latin/backoff.py
@@ -65,7 +65,7 @@ class BackoffLatinLemmatizer(object):
     ###    original Latin lemmatizer from cltk.stem
     """
 
-    models_path = os.path.expanduser('~/cltk_data/latin/model/latin_models_cltk/lemmata/backoff')
+    models_path = os.path.normpath(get_cltk_data_dir() + '/latin/model/latin_models_cltk/lemmata/backoff')
 
     def __init__(self: object, train: List[list] = None, seed: int = 3, verbose: bool = False):
         self.models_path = BackoffLatinLemmatizer.models_path

--- a/cltk/prosody/latin/macronizer.py
+++ b/cltk/prosody/latin/macronizer.py
@@ -39,7 +39,7 @@ class Macronizer:
             "Macronizer not available for '{0}' tagger.".format(self.tagger)
 
     def _setup_macrons_data(self):
-        rel_path = "~/cltk_data/latin/model/latin_models_cltk/taggers/macrons/macrons.py"
+        rel_path = get_cltk_data_dir() + "/latin/model/latin_models_cltk/taggers/macrons/macrons.py"
         path = os.path.expanduser(rel_path)
         loader = importlib.machinery.SourceFileLoader("macrons", path)
         module = loader.load_module()

--- a/cltk/semantics/latin/lookup.py
+++ b/cltk/semantics/latin/lookup.py
@@ -26,7 +26,7 @@ class Lemmata:
         """Check for availability of the specified dictionary."""
         filename = self.dictionary + '.py'
         models = self.language + '_models_cltk'
-        rel_path = os.path.join('~/cltk_data',
+        rel_path = os.path.join(get_cltk_data_dir(),
                                 self.language,
                                 'model',
                                 models,

--- a/cltk/stem/latin/declension.py
+++ b/cltk/stem/latin/declension.py
@@ -36,7 +36,7 @@ class CollatinusDecliner:
 
     """
     def __init__(self):
-        path = os.path.join('~', 'cltk_data',
+        path = os.path.join(get_cltk_data_dir(),
                                 'latin', 'model', 'latin_models_cltk',
                                 'lemmata', 'collatinus', 'collected.json')
         path = os.path.expanduser(path)

--- a/cltk/stem/lemma.py
+++ b/cltk/stem/lemma.py
@@ -31,7 +31,7 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
                         "LemmaReplacer is deprecated and will soon be removed from CLTK. Please use the BackoffLatinLemmatizer at cltk.lemmatize.latin.backoff.",
                         DeprecationWarning,
                         stacklevel=2)
-            rel_path = os.path.join('~','cltk_data',
+            rel_path = os.path.join(get_cltk_data_dir(),
                                     self.language,
                                     'model','latin_models_cltk',
                                     'lemmata','latin_lemmata_cltk.py')
@@ -40,7 +40,7 @@ class LemmaReplacer(object):  # pylint: disable=too-few-public-methods
             loader = importlib.machinery.SourceFileLoader('latin_lemmata_cltk', path)
 
         elif self.language == 'greek':
-            rel_path = os.path.join('~','cltk_data',
+            rel_path = os.path.join(get_cltk_data_dir(),
                                     self.language,
                                     'model','greek_models_cltk',
                                     'lemmata','greek_lemmata_cltk.py')

--- a/cltk/stem/sanskrit/indian_syllabifier.py
+++ b/cltk/stem/sanskrit/indian_syllabifier.py
@@ -89,8 +89,7 @@ class Syllabifier:
         variables which define the phonetic vectors.
         """
 
-        root = os.path.expanduser('~')
-        csv_dir_path = os.path.join(root, 'cltk_data/sanskrit/model/sanskrit_models_cltk/phonetics')
+        csv_dir_path = get_cltk_data_dir() + '/sanskrit/model/sanskrit_models_cltk/phonetics'
 
         all_phonetic_csv = os.path.join(csv_dir_path, 'all_script_phonetic_data.csv')
         tamil_csv = os.path.join(csv_dir_path, 'tamil_script_phonetic_data.csv')

--- a/cltk/tag/ner.py
+++ b/cltk/tag/ner.py
@@ -9,8 +9,8 @@ import importlib.machinery
 __author__ = ['Natasha Voake <natashavoake@gmail.com>']
 __license__ = 'MIT License. See LICENSE.'
 
-NER_DICT = {'greek': '~/cltk_data/greek/model/greek_models_cltk/ner/proper_names.txt',
-            'latin': '~/cltk_data/latin/model/latin_models_cltk/ner/proper_names.txt'}
+NER_DICT = {'greek': get_cltk_data_dir() + '/greek/model/greek_models_cltk/ner/proper_names.txt',
+            'latin': get_cltk_data_dir() + '/latin/model/latin_models_cltk/ner/proper_names.txt'}
 
 
 class NamedEntityReplacer(object):
@@ -21,7 +21,7 @@ class NamedEntityReplacer(object):
 
 
     def _load_necessary_data(self):
-        rel_path = os.path.join('~', 'cltk_data',
+        rel_path = os.path.join(get_cltk_data_dir(),
                                 'french',
                                 'text', 'french_data_cltk',
                                 'named_entities_fr.py')

--- a/cltk/tag/pos.py
+++ b/cltk/tag/pos.py
@@ -60,7 +60,7 @@ class POSTag:
         """
         assert lang in TAGGERS.keys(), \
             'POS tagger not available for {0} language.'.format(lang)
-        rel_path = os.path.join('~/cltk_data',
+        rel_path = os.path.join(get_cltk_data_dir(),
                                 lang,
                                 'model/' + lang + '_models_cltk/taggers/pos')  # pylint: disable=C0301
         path = os.path.expanduser(rel_path)

--- a/cltk/tests/test_corpus/test_corpus.py
+++ b/cltk/tests/test_corpus/test_corpus.py
@@ -61,7 +61,7 @@ from cltk.utils.matrix_corpus_fun import distinct_words
 
 __license__ = 'MIT License. See LICENSE.'
 
-DISTRIBUTED_CORPUS_PATH_REL = '~/cltk_data/test_distributed_corpora.yaml'
+DISTRIBUTED_CORPUS_PATH_REL = get_cltk_data_dir() + '/test_distributed_corpora.yaml'
 DISTRIBUTED_CORPUS_PATH = os.path.expanduser(DISTRIBUTED_CORPUS_PATH_REL)
 
 
@@ -118,7 +118,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         """Test cloning TLGU."""
         corpus_importer = CorpusImporter('greek')
         corpus_importer.import_corpus('greek_software_tlgu')
-        file_rel = os.path.join('~/cltk_data/greek/software/greek_software_tlgu/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/greek/software/greek_software_tlgu/README.md')
         _file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(_file)
         self.assertTrue(file_exists)
@@ -130,7 +130,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         Note: assertEqual fails on some accented characters ('ή', 'ί').
         """
         in_test = os.path.abspath('cltk/tests/test_nlp/tlgu_test_text_beta_code.txt')
-        out_test = os.path.expanduser('~/cltk_data/tlgu_test_text_unicode.txt')
+        out_test = os.path.normpath(get_cltk_data_dir() + '/tlgu_test_text_unicode.txt')
         tlgu = TLGU(testing=True)
         tlgu.convert(in_test, out_test)
         with open(out_test) as out_file:
@@ -302,7 +302,7 @@ argenteo polubro, aureo eclutro. """
         """Test cloning the Latin Library text corpus."""
         corpus_importer = CorpusImporter('latin')
         corpus_importer.import_corpus('latin_text_latin_library')
-        file_rel = os.path.join('~/cltk_data/latin/text/latin_text_latin_library/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/latin/text/latin_text_latin_library/README.md')
         _file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(_file)
         self.assertTrue(file_exists)
@@ -361,7 +361,7 @@ argenteo polubro, aureo eclutro. """
         """Test cloning the CLTK Latin models."""
         corpus_importer = CorpusImporter('latin')
         corpus_importer.import_corpus('latin_models_cltk')
-        file_rel = os.path.join('~/cltk_data/latin/model/latin_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/latin/model/latin_models_cltk/README.md')
         _file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(_file)
         self.assertTrue(file_exists)
@@ -372,7 +372,7 @@ argenteo polubro, aureo eclutro. """
         """
         corpus_importer = CorpusImporter('greek')
         corpus_importer.import_corpus('greek_models_cltk')
-        file_rel = os.path.join('~/cltk_data/greek/model/greek_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/greek/model/greek_models_cltk/README.md')
         _file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(_file)
         self.assertTrue(file_exists)
@@ -394,7 +394,7 @@ argenteo polubro, aureo eclutro. """
         """Test cloning the Antique Latin from digilibLT."""
         corpus_importer = CorpusImporter('latin')
         corpus_importer.import_corpus('latin_text_antique_digiliblt')
-        file_rel = os.path.join('~/cltk_data/latin/text/latin_text_antique_digiliblt/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/latin/text/latin_text_antique_digiliblt/README.md')
         _file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(_file)
         self.assertTrue(file_exists)
@@ -543,7 +543,7 @@ argenteo polubro, aureo eclutro. """
 
     def make_distributed_corpora_testing_file(self):
         """Setup for some cloning tests, make file at
-        '~/cltk_data/test_distributed_corpora.yaml'.
+        get_cltk_data_dir() + '/test_distributed_corpora.yaml'.
         """
         # ! Don't format this literal string, must be YAML-ish
         yaml_str_to_write = """example_distributed_latin_corpus:
@@ -556,7 +556,7 @@ example_distributed_fake_language_corpus:
         language: fake_language
         type: treebank
     """
-        cltk_data_dir = os.path.expanduser('~/cltk_data')
+        cltk_data_dir = get_cltk_data_dir()
         if not os.path.isdir(cltk_data_dir):
             os.mkdir(cltk_data_dir)
         with open(DISTRIBUTED_CORPUS_PATH, 'w') as file_open:
@@ -615,7 +615,7 @@ example_distributed_fake_language_corpus:
     #     corpora_list = pun_import.list_corpora
     #     self.assertTrue('punjabi_text_gurban' in corpora_list)
     #     pun_import.import_corpus('punjabi_text_gurban')
-    #     file_path = os.path.join('~/cltk_data/punjabi/text/punjabi_text_gurban/README.md')
+    #     file_path = os.path.join(get_cltk_data_dir() + '/punjabi/text/punjabi_text_gurban/README.md')
     #     _file = os.path.expanduser(file_path)
     #     self.assertTrue(os.path.isfile(_file))
     #

--- a/cltk/tests/test_languages/test_old_english.py
+++ b/cltk/tests/test_languages/test_old_english.py
@@ -17,7 +17,7 @@ class TestOldEnglish(unittest.TestCase):
     def setUp(self):
         corpus_importer = CorpusImporter("old_english")
         corpus_importer.import_corpus("old_english_models_cltk")
-        file_rel = os.path.join('~/cltk_data/old_english/model/old_english_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/old_english/model/old_english_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
@@ -37,8 +37,8 @@ class TestOldEnglish(unittest.TestCase):
     def test_dictionary_lemmatizer(self):
         lemmatizer = OldEnglishDictionaryLemmatizer()
         test_sentence = 'Næs him fruma æfre, or geworden, ne nu ende cymþ ecean'
-        target = [('Næs', 'næs'), ('him', 'he'), ('fruma', 'fruma'), ('æfre', 'æfre'), 
-            (',', ','), ('or', 'or'), ('geworden', 'weorþan'), (',', ','), ('ne', 'ne'), 
+        target = [('Næs', 'næs'), ('him', 'he'), ('fruma', 'fruma'), ('æfre', 'æfre'),
+            (',', ','), ('or', 'or'), ('geworden', 'weorþan'), (',', ','), ('ne', 'ne'),
             ('nu', 'nu'), ('ende', 'ende'), ('cymþ', 'cuman'), ('ecean', 'ecean')]
         self.assertEqual(lemmatizer.lemmatize(test_sentence), target)
 
@@ -52,7 +52,7 @@ class TestOldEnglish(unittest.TestCase):
     def test_dictionary_lemmatizer_list(self):
         lemmatizer = OldEnglishDictionaryLemmatizer()
         test_sentence = 'Him ða Scyld gewat to gescæphwile'
-        target = [('Him', 'he'), ('ða', 'þa'), ('Scyld', 'scyld'), 
+        target = [('Him', 'he'), ('ða', 'þa'), ('Scyld', 'scyld'),
         ('gewat', 'gewitan'), ('to', 'to'), ('gescæphwile', 'gescæphwile')]
         self.assertEqual(lemmatizer.lemmatize(test_sentence.split()), target)
 
@@ -63,7 +63,7 @@ class TestOldEnglish(unittest.TestCase):
 
     def test_dictionary_lemmatizer_evaluate(self):
         lemmatizer = OldEnglishDictionaryLemmatizer()
-        test_file = os.path.expanduser('~/cltk_data/old_english/model/old_english_models_cltk/texts/oe/beowulf.txt')
+        test_file = os.path.normpath(get_cltk_data_dir() + '/old_english/model/old_english_models_cltk/texts/oe/beowulf.txt')
         coverage = lemmatizer.evaluate(test_file)
         self.assertTrue(coverage > 0.5)
 

--- a/cltk/tests/test_languages/test_old_norse.py
+++ b/cltk/tests/test_languages/test_old_norse.py
@@ -27,7 +27,7 @@ class TestOldNorse(unittest.TestCase):
     def setUp(self):
         corpus_importer = CorpusImporter("old_norse")
         corpus_importer.import_corpus("old_norse_models_cltk")
-        file_rel = os.path.join('~/cltk_data/old_norse/model/old_norse_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/old_norse/model/old_norse_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)

--- a/cltk/tests/test_nlp/test_lemmatize.py
+++ b/cltk/tests/test_nlp/test_lemmatize.py
@@ -30,7 +30,7 @@ class TestSequenceFunctions(unittest.TestCase):
     def setUp(self):
         corpus_importer = CorpusImporter('french')
         corpus_importer.import_corpus('french_data_cltk')
-        file_rel = os.path.join('~/cltk_data/french/text/french_data_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/french/text/french_data_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)

--- a/cltk/tests/test_nlp/test_stem.py
+++ b/cltk/tests/test_nlp/test_stem.py
@@ -31,7 +31,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
     #     """
     #     corpus_importer = CorpusImporter('sanskrit')
     #     corpus_importer.import_corpus('sanskrit_models_cltk')
-    #     file_rel = os.path.join('~/cltk_data/sanskrit/model/sanskrit_models_cltk/README.md')
+    #     file_rel = os.path.join(get_cltk_data_dir() + '/sanskrit/model/sanskrit_models_cltk/README.md')
     #     file = os.path.expanduser(file_rel)
     #     file_exists = os.path.isfile(file)
     #     self.assertTrue(file_exists)

--- a/cltk/tests/test_nlp/test_stop.py
+++ b/cltk/tests/test_nlp/test_stop.py
@@ -31,14 +31,14 @@ class TestSequenceFunctions(unittest.TestCase):
         """
         corpus_importer = CorpusImporter('greek')
         corpus_importer.import_corpus('greek_models_cltk')
-        file_rel = os.path.join('~/cltk_data/greek/model/greek_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/greek/model/greek_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter('latin')
         corpus_importer.import_corpus('latin_models_cltk')
-        file_rel = os.path.join('~/cltk_data/latin/model/latin_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/latin/model/latin_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)

--- a/cltk/tests/test_nlp/test_tag.py
+++ b/cltk/tests/test_nlp/test_tag.py
@@ -22,42 +22,42 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         """
         corpus_importer = CorpusImporter('greek')
         corpus_importer.import_corpus('greek_models_cltk')
-        file_rel = os.path.join('~/cltk_data/greek/model/greek_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/greek/model/greek_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter('latin')
         corpus_importer.import_corpus('latin_models_cltk')
-        file_rel = os.path.join('~/cltk_data/latin/model/latin_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/latin/model/latin_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter('french')
         corpus_importer.import_corpus('french_data_cltk')
-        file_rel = os.path.join('~/cltk_data/french/text/french_data_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/french/text/french_data_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter("old_norse")
         corpus_importer.import_corpus("old_norse_models_cltk")
-        file_rel = os.path.join('~/cltk_data/old_norse/model/old_norse_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/old_norse/model/old_norse_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
         
         corpus_importer = CorpusImporter('middle_low_german')
         corpus_importer.import_corpus('middle_low_german_models_cltk')
-        file_rel = os.path.join('~/cltk_data/middle_low_german/model/middle_low_german_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/middle_low_german/model/middle_low_german_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter('old_english')
         corpus_importer.import_corpus('old_english_models_cltk')
-        file_rel = os.path.join('~/cltk_data/old_english/model/old_english_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/old_english/model/old_english_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
@@ -131,13 +131,13 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
     def test_check_latest_latin(self):
         """Test _check_latest_data()"""
         ner._check_latest_data('latin')
-        names_path = os.path.expanduser('~/cltk_data/latin/model/latin_models_cltk/ner/proper_names.txt')
+        names_path = os.path.normpath(get_cltk_data_dir() + '/latin/model/latin_models_cltk/ner/proper_names.txt')
         self.assertTrue(os.path.isfile(names_path))
 
     def test_check_latest_latin(self):
         """Test _check_latest_data()"""
-        path = '~/cltk_data/latin/model/latin_models_cltk'
-        #p = '~/cltk_data/latin/model/latin_models_cltk/ner/proper_names.txt'
+        path = get_cltk_data_dir() + '/latin/model/latin_models_cltk'
+        #p = get_cltk_data_dir() + '/latin/model/latin_models_cltk/ner/proper_names.txt'
         names_dir = os.path.expanduser(path)
         shutil.rmtree(names_dir, ignore_errors=True)
         ner._check_latest_data('latin')

--- a/cltk/tests/test_nlp/test_utils.py
+++ b/cltk/tests/test_nlp/test_utils.py
@@ -30,14 +30,14 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         """
         corpus_importer = CorpusImporter('greek')
         corpus_importer.import_corpus('greek_models_cltk')
-        file_rel = os.path.join('~/cltk_data/greek/model/greek_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/greek/model/greek_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
 
         corpus_importer = CorpusImporter('latin')
         corpus_importer.import_corpus('latin_models_cltk')
-        file_rel = os.path.join('~/cltk_data/latin/model/latin_models_cltk/README.md')
+        file_rel = os.path.join(get_cltk_data_dir() + '/latin/model/latin_models_cltk/README.md')
         file = os.path.expanduser(file_rel)
         file_exists = os.path.isfile(file)
         self.assertTrue(file_exists)
@@ -56,7 +56,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
 
     def test_logger(self):
         """Test the CLTK logger."""
-        home_dir = os.path.expanduser('~/cltk_data')
+        home_dir = get_cltk_data_dir()
         log_path = os.path.join(home_dir, 'cltk.log')
         self.assertTrue(log_path)
 
@@ -64,7 +64,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         """Test opening pickle. This requires ``greek_models_cltk``
         to have been run in ``setUp()``.
         """
-        pickle_path_rel = '~/cltk_data/greek/model/greek_models_cltk/tokenizers/sentence/greek.pickle'  # pylint: disable=line-too-long
+        pickle_path_rel = get_cltk_data_dir() + '/greek/model/greek_models_cltk/tokenizers/sentence/greek.pickle'  # pylint: disable=line-too-long
         pickle_path = os.path.expanduser(pickle_path_rel)
         a_pickle = open_pickle(pickle_path)
         self.assertTrue(a_pickle)
@@ -88,7 +88,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         of concordance builder. Doesn't test quality of output."""
         text = 'felices cantus ore sonante dedit'
         philology.write_concordance_from_string(text, 'test_string')
-        file = os.path.expanduser('~/cltk_data/user_data/concordance_test_string.txt')
+        file = os.path.normpath(get_cltk_data_dir() + '/user_data/concordance_test_string.txt')
         is_file = os.path.isfile(file)
         self.assertTrue(is_file)
 
@@ -97,7 +97,7 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
         of concordance builder. Doesn't test quality of output."""
         text_file = 'cltk/tests/test_nlp/text-file.txt'
         philology.write_concordance_from_file(text_file, 'test_file')
-        file_conc = os.path.expanduser('~/cltk_data/user_data/concordance_test_file.txt')
+        file_conc = os.path.normpath(get_cltk_data_dir() + '/user_data/concordance_test_file.txt')
         is_file = os.path.isfile(file_conc)
         self.assertTrue(is_file)
 
@@ -152,13 +152,12 @@ class TestPathCreation(unittest.TestCase):
 
     def test_empty_path(self):
         """Test empty empty_path()"""
-        self.assertEqual(make_cltk_path(),
-                         os.path.expanduser(os.path.join('~', 'cltk_data')))
+        self.assertEqual(make_cltk_path(), get_cltk_data_dir())
 
     def test_path(self):
         """Test empty_path() with argument."""
         self.assertEqual(make_cltk_path('greek', 'perseus_corpus'),
-                         os.path.expanduser(os.path.join('~', 'cltk_data', 'greek', 'perseus_corpus')))
+                         os.path.expanduser(os.path.join(get_cltk_data_dir(), 'greek', 'perseus_corpus')))
 
 
 if __name__ == '__main__':

--- a/cltk/tokenize/greek/sentence.py
+++ b/cltk/tokenize/greek/sentence.py
@@ -23,7 +23,7 @@ def SentenceTokenizer(tokenizer: str = 'regex'):
 class GreekPunktSentenceTokenizer(BasePunktSentenceTokenizer):
     """ PunktSentenceTokenizer trained on Ancient Greek
     """
-    models_path = '~/cltk_data/greek/model/greek_models_cltk/tokenizers/sentence'
+    models_path = get_cltk_data_dir() + '/greek/model/greek_models_cltk/tokenizers/sentence'
     missing_models_message = "GreekPunktSentenceTokenizer requires the ```greek_models_cltk``` to be in cltk_data. Please load this corpus."
 
     def __init__(self: object, language: str = 'greek'):

--- a/cltk/tokenize/latin/sentence.py
+++ b/cltk/tokenize/latin/sentence.py
@@ -18,7 +18,7 @@ def SentenceTokenizer(tokenizer:str = 'punkt'):
 class LatinPunktSentenceTokenizer(BasePunktSentenceTokenizer):
     """ PunktSentenceTokenizer trained on Latin
     """
-    models_path = os.path.expanduser('~/cltk_data/latin/model/latin_models_cltk/tokenizers/sentence')
+    models_path = os.path.normpath(get_cltk_data_dir() + '/latin/model/latin_models_cltk/tokenizers/sentence')
     missing_models_message = "BackoffLatinLemmatizer requires the ```latin_models_cltk``` to be in cltk_data. Please load this corpus."
 
     def __init__(self: object, language:str = 'latin'):

--- a/cltk/tokenize/sentence.py
+++ b/cltk/tokenize/sentence.py
@@ -51,7 +51,7 @@ class BaseSentenceTokenizer:
         return tokenizer.tokenize(text)
 
     def _get_models_path(self, language):  # pragma: no cover
-        return f'~/cltk_data/{language}/model/{language}_models_cltk/tokenizers/sentence'
+        return get_cltk_data_dir() + f'/{language}/model/{language}_models_cltk/tokenizers/sentence'
 
 
 class BasePunktSentenceTokenizer(BaseSentenceTokenizer):

--- a/cltk/utils/cltk_logger.py
+++ b/cltk/utils/cltk_logger.py
@@ -7,7 +7,7 @@ import os
 __author__ = ['Kyle P. Johnson <kyle@kyle-p-johnson.com>', 'Stephen Margheim <stephen.margheim@gmail.com>']
 __license__ = 'MIT License. See LICENSE.'
 
-home_dir = os.path.expanduser('~/cltk_data')  # pylint: disable=invalid-name
+home_dir = get_cltk_data_dir()  # pylint: disable=invalid-name
 log_path = os.path.join(home_dir, 'cltk.log')  # pylint: disable=invalid-name
 
 if not os.path.isdir(home_dir):

--- a/cltk/utils/file_operations.py
+++ b/cltk/utils/file_operations.py
@@ -12,7 +12,7 @@ __license__ = 'MIT License. See LICENSE.'
 
 def make_cltk_path(*fp_list):
     """Take arbitrary number of str arguments (not list) and return expanded,
-    absolute path to a user's cltk_data dir.
+    absolute path to a user's (or user-defined) cltk_data dir.
 
     Example:
     In [8]: make_cltk_path('greek', 'model', 'greek_models_cltk')
@@ -22,9 +22,8 @@ def make_cltk_path(*fp_list):
     :param: : fp_list tokens to join together beginning from cltk_root folder
     :rtype: str
     """
-    
-    home = os.path.expanduser('~')
-    return os.path.join(home, 'cltk_data', *fp_list)
+
+    return os.path.join(get_cltk_data_dir(), *fp_list)
 
 
 def open_pickle(path: str):

--- a/cltk/utils/philology.py
+++ b/cltk/utils/philology.py
@@ -56,7 +56,7 @@ def build_concordance(text_str: str) -> List[List[str]]:
 def write_concordance_from_string(text: str, name: str) -> None:
     """A reworkinng of write_concordance_from_file(). Refactor these."""
     list_of_lists = build_concordance(text)  # type: List[List[str]]
-    user_data_rel = '~/cltk_data/user_data'  # type: str
+    user_data_rel = get_cltk_data_dir() + '/user_data'  # type: str
     user_data = os.path.expanduser(user_data_rel)  # type: str
     if not os.path.isdir(user_data):
         os.makedirs(user_data)
@@ -76,7 +76,7 @@ def write_concordance_from_string(text: str, name: str) -> None:
 def write_concordance_from_file(filepaths: Union[str, List[str]], name: str) -> None:
     """This calls the modified ConcordanceIndex, taken and modified from
     the NLTK, and writes to disk a file named 'concordance_' + name at
-    '~/cltk_data/user_data/'.
+    get_cltk_data_dir() + '/user_data/'.
 
     TODO: Add language (here or in class), lowercase option, stemming/
     lemmatization, else?
@@ -94,7 +94,7 @@ def write_concordance_from_file(filepaths: Union[str, List[str]], name: str) -> 
         for filepath in filepaths:
             text += read_file(filepath)
     list_of_lists = build_concordance(text)  # type: List[List[str]]
-    user_data_rel = '~/cltk_data/user_data'  # type: str
+    user_data_rel = get_cltk_data_dir() + '/user_data'  # type: str
     user_data = os.path.expanduser(user_data_rel)  # type: str
     if not os.path.isdir(user_data):
         os.makedirs(user_data)

--- a/cltk/vector/word2vec.py
+++ b/cltk/vector/word2vec.py
@@ -139,8 +139,8 @@ def get_sims(word, language, lemmatized=False, threshold=0.70):
         # for all languages, especially Greek.
         word = jv_replacer.replace(word).casefold()
 
-    model_dirs = {'greek': '~/cltk_data/greek/model/greek_word2vec_cltk',
-                  'latin': '~/cltk_data/latin/model/latin_word2vec_cltk'}
+    model_dirs = {'greek': get_cltk_data_dir() + '/greek/model/greek_word2vec_cltk',
+                  'latin': get_cltk_data_dir() + '/latin/model/latin_word2vec_cltk'}
     assert language in model_dirs.keys(), 'Langauges available with Word2Vec model: {}'.format(model_dirs.keys())
     if lemmatized:
         lemma_str = '_lemmed'


### PR DESCRIPTION
These changes address issue #196 by implementing a function (namely `get_cltk_data_dir()`), available to all code that runs *within* the CLTK package as well as to end users of the package itself, that uses the `$CLTK_DATA` environment variable to deduce its location, or falls back to the default and usual `~/cltk_data` if no such environment variable is defined.