### PR TITLE
Add parameter for punctuation used by Latin punkt sentence tokenizer

### DIFF
--- a/cltk/tests/test_nlp/test_tokenize.py
+++ b/cltk/tests/test_nlp/test_tokenize.py
@@ -50,8 +50,14 @@ class TestSentenceTokenize(unittest.TestCase):  # pylint: disable=R0904
                   'Hos ego video consul et de re publica sententiam rogo et, quos ferro trucidari oportebat, eos nondum voce volnero!',
                   'Fuisti igitur apud Laecam illa nocte, Catilina, distribuisti partes Italiae, statuisti, quo quemque proficisci placeret, delegisti, quos Romae relinqueres, quos tecum educeres, discripsisti urbis partes ad incendia, confirmasti te ipsum iam esse exiturum, dixisti paulum tibi esse etiam nunc morae, quod ego viverem.']  # pylint: disable=line-too-long
         tokenizer = LatinPunktSentenceTokenizer()
-        # print(tokenizer.models_path)
         tokenized_sentences = tokenizer.tokenize(self.latin_text)
+        self.assertEqual(tokenized_sentences, target)
+
+    def test_sentence_tokenizer_latin_punkt_strict(self):
+        """Test tokenizing Latin sentences with stricter punctuation."""
+        target = ['in principio creavit Deus caelum et terram;', 'terra autem erat inanis et vacua et tenebrae super faciem abyssi et spiritus Dei ferebatur super aquas;', 'dixitque Deus fiat lux et facta est lux;', 'et vidit Deus lucem quod esset bona et divisit lucem ac tenebras.']  # pylint: disable=line-too-long
+        tokenizer = LatinPunktSentenceTokenizer(strict=True)
+        tokenized_sentences = tokenizer.tokenize("""in principio creavit Deus caelum et terram; terra autem erat inanis et vacua et tenebrae super faciem abyssi et spiritus Dei ferebatur super aquas; dixitque Deus fiat lux et facta est lux; et vidit Deus lucem quod esset bona et divisit lucem ac tenebras.""")
         self.assertEqual(tokenized_sentences, target)
 
     # Deprecated use cltk.tokenize.latin.sentence

--- a/cltk/tests/test_nlp/test_tokenize.py
+++ b/cltk/tests/test_nlp/test_tokenize.py
@@ -50,7 +50,7 @@ class TestSentenceTokenize(unittest.TestCase):  # pylint: disable=R0904
                   'Hos ego video consul et de re publica sententiam rogo et, quos ferro trucidari oportebat, eos nondum voce volnero!',
                   'Fuisti igitur apud Laecam illa nocte, Catilina, distribuisti partes Italiae, statuisti, quo quemque proficisci placeret, delegisti, quos Romae relinqueres, quos tecum educeres, discripsisti urbis partes ad incendia, confirmasti te ipsum iam esse exiturum, dixisti paulum tibi esse etiam nunc morae, quod ego viverem.']  # pylint: disable=line-too-long
         tokenizer = LatinPunktSentenceTokenizer()
-        print(tokenizer.models_path)
+        # print(tokenizer.models_path)
         tokenized_sentences = tokenizer.tokenize(self.latin_text)
         self.assertEqual(tokenized_sentences, target)
 

--- a/cltk/tokenize/latin/params.py
+++ b/cltk/tokenize/latin/params.py
@@ -154,3 +154,6 @@ latin_replacements = [
 
 class LatinLanguageVars(PunktLanguageVars):
     _re_non_word_chars = PunktLanguageVars._re_non_word_chars.replace("'",'')
+
+PUNCTUATION = ('.', '?', '!')
+STRICT_PUNCTUATION = PUNCTUATION+('-', ':', ';')

--- a/cltk/tokenize/latin/sentence.py
+++ b/cltk/tokenize/latin/sentence.py
@@ -31,8 +31,8 @@ class LatinPunktSentenceTokenizer(BasePunktSentenceTokenizer):
         """
         self.lang_vars = LatinLanguageVars()
         self.strict = strict
-        self.models_path = LatinPunktSentenceTokenizer.models_path
         super().__init__(language='latin', lang_vars=self.lang_vars)
+        self.models_path = LatinPunktSentenceTokenizer.models_path
 
         try:
             self.model =  open_pickle(os.path.join(self.models_path, 'latin_punkt.pickle'))
@@ -43,10 +43,4 @@ class LatinPunktSentenceTokenizer(BasePunktSentenceTokenizer):
             PunktLanguageVars.sent_end_chars=STRICT_PUNCTUATION
         else:
             PunktLanguageVars.sent_end_chars=PUNCTUATION
-
-
-if __name__ == "__main__":
-    t = LatinPunktSentenceTokenizer(strict=True)
-    test = """in principio creavit Deus caelum et terram; terra autem erat inanis et vacua et tenebrae super faciem abyssi et spiritus Dei ferebatur super aquas; dixitque Deus fiat lux et facta est lux; et vidit Deus lucem quod esset bona et divisit lucem ac tenebras."""
-    sents = t.tokenize(test)
-    print(sents)
+         

--- a/cltk/tokenize/latin/sentence.py
+++ b/cltk/tokenize/latin/sentence.py
@@ -11,9 +11,9 @@ from cltk.tokenize.sentence import BaseSentenceTokenizer, BasePunktSentenceToken
 from cltk.tokenize.latin.params import LatinLanguageVars, PUNCTUATION, STRICT_PUNCTUATION
 from cltk.utils.file_operations import open_pickle
 
-def SentenceTokenizer(tokenizer:str = 'punkt'):
+def SentenceTokenizer(tokenizer:str = 'punkt', strict:bool = False):
     if tokenizer=='punkt':
-        return LatinPunktSentenceTokenizer()
+        return LatinPunktSentenceTokenizer(strict=strict)
 
 
 class LatinPunktSentenceTokenizer(BasePunktSentenceTokenizer):
@@ -43,4 +43,3 @@ class LatinPunktSentenceTokenizer(BasePunktSentenceTokenizer):
             PunktLanguageVars.sent_end_chars=STRICT_PUNCTUATION
         else:
             PunktLanguageVars.sent_end_chars=PUNCTUATION
-         

--- a/cltk/tokenize/latin/sentence.py
+++ b/cltk/tokenize/latin/sentence.py
@@ -5,9 +5,10 @@ __author__ = ['Patrick J. Burns <patrick@diyclassics.org>']
 __license__ = 'MIT License.'
 
 import os.path
-
+import nltk
+from nltk.tokenize.punkt import PunktLanguageVars
 from cltk.tokenize.sentence import BaseSentenceTokenizer, BasePunktSentenceTokenizer
-from cltk.tokenize.latin.params import LatinLanguageVars
+from cltk.tokenize.latin.params import LatinLanguageVars, PUNCTUATION, STRICT_PUNCTUATION
 from cltk.utils.file_operations import open_pickle
 
 def SentenceTokenizer(tokenizer:str = 'punkt'):
@@ -19,18 +20,33 @@ class LatinPunktSentenceTokenizer(BasePunktSentenceTokenizer):
     """ PunktSentenceTokenizer trained on Latin
     """
     models_path = os.path.normpath(get_cltk_data_dir() + '/latin/model/latin_models_cltk/tokenizers/sentence')
-    missing_models_message = "BackoffLatinLemmatizer requires the ```latin_models_cltk``` to be in cltk_data. Please load this corpus."
+    missing_models_message = "LatinPunktSentenceTokenizer requires the ```latin_models_cltk``` to be in cltk_data. Please load this corpus."
 
-    def __init__(self: object, language:str = 'latin'):
+    def __init__(self: object, language:str = 'latin', strict:bool = False):
         """
         :param language : language for sentence tokenization
         :type language: str
+        :param strict : allow for stricter puctuation for sentence tokenization
+        :type strict: bool
         """
         self.lang_vars = LatinLanguageVars()
-        super().__init__(language='latin', lang_vars=self.lang_vars)
+        self.strict = strict
         self.models_path = LatinPunktSentenceTokenizer.models_path
+        super().__init__(language='latin', lang_vars=self.lang_vars)
 
         try:
             self.model =  open_pickle(os.path.join(self.models_path, 'latin_punkt.pickle'))
         except FileNotFoundError as err:
             raise type(err)(LatinPunktSentenceTokenizer.missing_models_message)
+
+        if self.strict:
+            PunktLanguageVars.sent_end_chars=STRICT_PUNCTUATION
+        else:
+            PunktLanguageVars.sent_end_chars=PUNCTUATION
+
+
+if __name__ == "__main__":
+    t = LatinPunktSentenceTokenizer(strict=True)
+    test = """in principio creavit Deus caelum et terram; terra autem erat inanis et vacua et tenebrae super faciem abyssi et spiritus Dei ferebatur super aquas; dixitque Deus fiat lux et facta est lux; et vidit Deus lucem quod esset bona et divisit lucem ac tenebras."""
+    sents = t.tokenize(test)
+    print(sents)

--- a/cltk/tokenize/sentence.py
+++ b/cltk/tokenize/sentence.py
@@ -164,11 +164,3 @@ class TokenizeSentence(BasePunktSentenceTokenizer):  # pylint: disable=R0903
         :param untokenized_string: A string containing one of more sentences.
         """
         return self.tokenize_sentences(untokenized_string)
-
-if __name__ == "__main__":
-    text = """श्री भगवानुवाच भूय एव महाबाहो श्रृणु मे परमं वचः। यत्तेऽहं प्रीयमाणाय वक्ष्यामि हितकाम्यया।।
-न मे विदुः सुरगणाः प्रभवं न महर्षयः। अहमादिर्हि देवानां महर्षीणां च सर्वशः।।"""
-    t = TokenizeSentence('sanskrit')
-    sents = t.tokenize(text)
-    for i, sent in enumerate(sents, 1):
-        print(f'{i}: {sent}')

--- a/docs/latin.rst
+++ b/docs/latin.rst
@@ -753,6 +753,17 @@ Sentence tokenization for Latin is available using a [Punkt](https://www.nltk.or
 
 Note that the Latin sentence tokenizer takes account of abbreviations like 'Kal.' and 'C.' and does not split sentences at these points.
 
+By default, the Latin Punkt Sentence Tokenizer splits on period, question mark, and exclamation point. There is a ```strict``` parameter that adds colon, semicolon, and hyphen to this.
+
+.. code-block:: python
+
+In [5]: sent_tokenizer = SentenceTokenizer(strict=True)
+
+In [6]: untokenized_text = 'In principio creavit Deus caelum et terram; terra autem erat inanis et vacua et tenebrae super faciem abyssi et spiritus Dei ferebatur super aquas; dixitque Deus fiat lux et facta est lux; et vidit Deus lucem quod esset bona et divisit lucem ac tenebras.'
+
+In [7]: sent_tokenizer.tokenize(untokenized_text)
+Out[7]: ['In principio creavit Deus caelum et terram;', 'terra autem erat inanis et vacua et tenebrae super faciem abyssi et spiritus Dei ferebatur super aquas;', 'dixitque Deus fiat lux et facta est lux;', 'et vidit Deus lucem quod esset bona et divisit lucem ac tenebras.']
+
 NB: The old method for sentence tokenizer, i.e. TokenizeSentence, is still available, but now calls the tokenizer described above.
 
 .. code-block:: python


### PR DESCRIPTION
Adds a ```strict`` parameter to the Latin Punkt tokenizer that extends the list of punctuation used for sentence segmentation from period, question mark, and exclamation point to also include colon, semicolon, and hyphen. Includes test and docs. Fixes #943. 