### PR TITLE
Update TLG cleanup with new angle bracket

### DIFF
--- a/cltk/corpus/utils/formatter.py
+++ b/cltk/corpus/utils/formatter.py
@@ -91,7 +91,7 @@ def tlg_plaintext_cleanup(text, rm_punctuation=False, rm_periods=False):
     TODO: Surely more junk to pull out. Please submit bugs!
     """
     remove_comp = regex.compile(
-        r"-\n|[«»<>\(\)‘’_—:!\?\'\"\*]|{[[:print:][:space:]]+?}|\[[[:print:][:space:]]+?\]|[a-zA-Z0-9]",
+        r"-\n|[«»<>〈〉\(\)‘’_—:!\?\'\"\*]|{[[:print:][:space:]]+?}|\[[[:print:][:space:]]+?\]|[a-zA-Z0-9]",
         flags=regex.VERSION1,
     )
     text = remove_comp.sub("", text)

--- a/cltk/tests/test_corpus/test_corpus.py
+++ b/cltk/tests/test_corpus/test_corpus.py
@@ -163,16 +163,16 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
 
     def test_tlg_plaintext_cleanup(self):
         """Test post-TLGU cleanup of text of Greek TLG text."""
-        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου〈πατήρ〉: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
+        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου 〈πατήρ〉: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
         clean = tlg_plaintext_cleanup(dirty, rm_punctuation=True, rm_periods=False)
-        target = " Ἀθήναιος μὲν ὁ τῆς βίβλουπατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."
+        target = " Ἀθήναιος μὲν ὁ τῆς βίβλου πατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."
         self.assertEqual(clean, target)
 
     def test_tlg_plaintext_cleanup_rm_periods(self):
         """Test post-TLGU cleanup of text of Greek TLG text."""
-        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου〈πατήρ〉: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
+        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου 〈πατήρ〉: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
         clean = tlg_plaintext_cleanup(dirty, rm_punctuation=True, rm_periods=True)
-        target = " Ἀθήναιος μὲν ὁ τῆς βίβλουπατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην"
+        target = " Ἀθήναιος μὲν ὁ τῆς βίβλου πατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην"
         self.assertEqual(clean, target)
 
     def test_phi5_plaintext_cleanup(self):

--- a/cltk/tests/test_corpus/test_corpus.py
+++ b/cltk/tests/test_corpus/test_corpus.py
@@ -163,16 +163,16 @@ class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
 
     def test_tlg_plaintext_cleanup(self):
         """Test post-TLGU cleanup of text of Greek TLG text."""
-        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου πατήρ: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
+        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου〈πατήρ〉: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
         clean = tlg_plaintext_cleanup(dirty, rm_punctuation=True, rm_periods=False)
-        target = " Ἀθήναιος μὲν ὁ τῆς βίβλου πατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."
+        target = " Ἀθήναιος μὲν ὁ τῆς βίβλουπατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."
         self.assertEqual(clean, target)
 
     def test_tlg_plaintext_cleanup_rm_periods(self):
         """Test post-TLGU cleanup of text of Greek TLG text."""
-        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου πατήρ: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
+        dirty = """{ΑΘΗΝΑΙΟΥ ΝΑΥΚΡΑΤΙΤΟΥ ΔΕΙΠΝΟΣΟΦΙΣΤΩΝ} LATIN Ἀθήναιος (μὲν) ὁ τῆς 999 βίβλου〈πατήρ〉: ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην."""  # pylint: disable=line-too-long
         clean = tlg_plaintext_cleanup(dirty, rm_punctuation=True, rm_periods=True)
-        target = " Ἀθήναιος μὲν ὁ τῆς βίβλου πατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην"
+        target = " Ἀθήναιος μὲν ὁ τῆς βίβλουπατήρ ποιεῖται δὲ τὸν λόγον πρὸς Τιμοκράτην"
         self.assertEqual(clean, target)
 
     def test_phi5_plaintext_cleanup(self):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     name='cltk',
     packages=find_packages(),
     url='https://github.com/cltk/cltk',
-    version='0.1.120',
+    version='0.1.121',
     zip_safe=True,
     test_suite='cltk.tests.test_cltk',
 )


### PR DESCRIPTION
Following up on #953 and the latest v1.8 of TLGU, which uses a new kind of pointed bracket to signify an editor's addition. Example taken from text number 1560, *Matthiae Traditiones*:

```
ἔστι γάρ, φησίν, ἐκεῖνο οὐχ ἁπλῶς ἄρρητον, 〈ὃ〉 ὀνομάζεται·
```

cc @pharos-alexandria you may want to re-run your TLG scripts with the latest version of TLGU