### PR TITLE
Implement normalized representations of morphosyntactic features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ updateDependencies:
 	poetry update
 
 uml:
-	cd docs/ && poetry run pyreverse -o png ../src/cltk/ && cd ../
+	cd docs/ && poetry run pyreverse -o svg ../src/cltk/ && cd ../
 
 all: format lint typing test uml docs
 

--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -15,7 +15,10 @@ from typing import Dict, List, Type
 
 import numpy as np
 
-from cltk.morphology.morphosyntax import MorphosyntacticFeature, MorphosyntacticFeatureBundle
+from cltk.morphology.morphosyntax import (
+    MorphosyntacticFeature,
+    MorphosyntacticFeatureBundle,
+)
 
 
 @dataclass
@@ -60,7 +63,7 @@ class Word:
     >>> Word(index_char_start=0, index_char_stop=6, index_token=0, string=get_example_text("lat")[0:6], pos="nom")
     Word(index_char_start=0, index_char_stop=6, index_token=0, index_sentence=None, string='Gallia', pos='nom', \
 lemma=None, stem=None, scansion=None, xpos=None, upos=None, dependency_relation=None, governor=None, features=None, \
-embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcription=None)
+category=None, embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcription=None)
     """
 
     index_char_start: int = None
@@ -76,7 +79,7 @@ embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcrip
     upos: str = None  # universal POS tag (from stanza)
     dependency_relation: str = None  # (from stanza)
     governor: int = None
-    features: MorphosyntacticFeatureBundle = MorphosyntacticFeatureBundle()
+    features: MorphosyntacticFeatureBundle = None
     category: MorphosyntacticFeatureBundle = None
     embedding: np.ndarray = None
     stop: bool = None
@@ -84,8 +87,10 @@ embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcrip
     syllables: List[str] = None
     phonetic_transcription: str = None
 
-    def __getitem__(self, feature_name: Type[MorphosyntacticFeature]) -> List[MorphosyntacticFeature]:
-        return self.feature_bundle[feature_name]
+    def __getitem__(
+        self, feature_name: Type[MorphosyntacticFeature]
+    ) -> List[MorphosyntacticFeature]:
+        return self.features[feature_name]
 
 
 @dataclass
@@ -110,7 +115,7 @@ class Doc:
     >>> cltk_doc.pos[:3]
     ['NOUN', 'AUX', 'PRON']
     >>> cltk_doc.morphosyntactic_features[:3]
-    [{'Case': 'Nom', 'Degree': 'Pos', 'Gender': 'Fem', 'Number': 'Sing'}, {'Mood': 'Ind', 'Number': 'Sing', 'Person': '3', 'Tense': 'Pres', 'VerbForm': 'Fin', 'Voice': 'Act'}, {'Case': 'Nom', 'Degree': 'Pos', 'Gender': 'Fem', 'Number': 'Sing', 'PronType': 'Ind'}]
+    [{Case: [nominative], Degree: [positive], Gender: [feminine], Number: [singular]}, {Mood: [indicative], Number: [singular], Person: [third], Tense: [present], VerbForm: [finite], Voice: [active]}, {Case: [nominative], Degree: [positive], Gender: [feminine], Number: [singular], PrononimalType: [indefinite]}]
     >>> cltk_doc.lemmata[:5]
     ['mallis', 'sum', 'omnis', 'divido', 'in']
     >>> len(cltk_doc.sentences)

--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -13,7 +13,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, Type
 
-import numpy
+import numpy as np
+
+from cltk.morphology.morphosyntax import MorphosyntacticFeature, MorphosyntacticFeatureBundle
 
 
 @dataclass
@@ -74,12 +76,16 @@ embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcrip
     upos: str = None  # universal POS tag (from stanza)
     dependency_relation: str = None  # (from stanza)
     governor: int = None
-    features: Dict[str, str] = None  # morphological features (from stanza)
-    embedding: numpy.ndarray = None
+    features: MorphosyntacticFeatureBundle = MorphosyntacticFeatureBundle()
+    category: MorphosyntacticFeatureBundle = None
+    embedding: np.ndarray = None
     stop: bool = None
     named_entity: bool = None
     syllables: List[str] = None
     phonetic_transcription: str = None
+
+    def __getitem__(self, feature_name: Type[MorphosyntacticFeature]) -> List[MorphosyntacticFeature]:
+        return self.feature_bundle[feature_name]
 
 
 @dataclass
@@ -131,8 +137,8 @@ class Doc:
     True
     >>> cltk_doc.sentences_strings[1]
     'Hi omnes lingua , institutis , legibus inter se differunt .'
-    >>> import numpy
-    >>> isinstance(cltk_doc.embeddings[1], numpy.ndarray)
+    >>> import numpy as np
+    >>> isinstance(cltk_doc.embeddings[1], np.ndarray)
     True
     """
 

--- a/src/cltk/dependency/processes.py
+++ b/src/cltk/dependency/processes.py
@@ -10,7 +10,11 @@ from boltons.cacheutils import cachedproperty
 from cltk.core.data_types import Doc, Process, Word
 from cltk.dependency.stanza import StanzaWrapper
 from cltk.dependency.tree import DependencyTree
-from cltk.morphology.morphosyntax import from_ud, to_categorial, MorphosyntacticFeatureBundle
+from cltk.morphology.morphosyntax import (
+    MorphosyntacticFeatureBundle,
+    from_ud,
+    to_categorial,
+)
 
 
 @dataclass
@@ -67,9 +71,13 @@ class StanzaProcess(Process):
         >>> isinstance(cltk_words[0], Word)
         True
         >>> cltk_words[0]
-        Word(index_char_start=None, index_char_stop=None, index_token=0, index_sentence=0, string='Gallia', pos=<POS.noun: 8>, lemma='mallis', stem=None, scansion=None, xpos='A1|grn1|casA|gen2', upos='NOUN', dependency_relation='nsubj', governor=3, features={<enum 'Case'>: [<Case.nominative: 1>], <enum 'Degree'>: [<Degree.positive: 4>], <enum 'Gender'>: [<Gender.feminine: 2>], <enum 'Number'>: [<Number.singular: 10>]}, category={<enum 'F'>: [<F.neg: 2>], <enum 'N'>: [<N.pos: 1>], <enum 'V'>: [<V.neg: 2>]}, embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcription=None)
+        Word(index_char_start=None, index_char_stop=None, index_token=0, index_sentence=0, string='Gallia', \
+pos=noun, lemma='mallis', stem=None, scansion=None, xpos='A1|grn1|casA|gen2', upos='NOUN', \
+dependency_relation='nsubj', governor=3, \
+features={Case: [nominative], Degree: [positive], Gender: [feminine], Number: [singular]}, category={F: [neg], N: [pos], V: [neg]}, \
+embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcription=None)
         """
-        
+
         words_list = list()  # type: List[Word]
 
         for sentence_index, sentence in enumerate(stanza_doc.sentences):
@@ -85,7 +93,7 @@ class StanzaProcess(Process):
                     - 1,  # subtract 1 from id b/c snpl starts their index at 1
                     index_sentence=sentence_index,
                     string=stanza_word.text,  # same as ``token.text``
-                    pos=from_ud('POS', stanza_word.pos),
+                    pos=from_ud("POS", stanza_word.pos),
                     xpos=stanza_word.xpos,
                     upos=stanza_word.upos,
                     lemma=stanza_word.lemma,
@@ -96,8 +104,15 @@ class StanzaProcess(Process):
                 )  # type: Word
 
                 # convert UD features to the normalized CLTK features
-                features = [tuple(f.split("=")) for f in stanza_word.feats.split("|")] if stanza_word.feats else []
-                cltk_features = [from_ud(feature_name, feature_value) for feature_name, feature_value in features]
+                features = (
+                    [tuple(f.split("=")) for f in stanza_word.feats.split("|")]
+                    if stanza_word.feats
+                    else []
+                )
+                cltk_features = [
+                    from_ud(feature_name, feature_value)
+                    for feature_name, feature_value in features
+                ]
                 cltk_word.features = MorphosyntacticFeatureBundle(*cltk_features)
                 cltk_word.category = to_categorial(cltk_word.pos)
 

--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -1,16 +1,19 @@
 """A module for representing universal morphosyntactic feature bundles."""
 
-from enum import IntEnum, auto
+from enum import auto
 from typing import List, Type, Union
 
 from cltk.core.exceptions import CLTKException
+from cltk.utils.utils import CLTKEnum
 
 __author__ = ["John Stewart <free-variation>"]
 
 
-class MorphosyntacticFeature(IntEnum):
-    def __eq__(self: "MorphosyntacticFeature", other: "MorphosyntacticFeature") -> bool:
-        return False if type(self) != type(other) else IntEnum.__eq__(self, other)
+class MorphosyntacticFeature(CLTKEnum):
+    """A generic multivalued morphosyntactic feature.
+    """
+
+    pass
 
 
 class PrivativeFeature(MorphosyntacticFeature):
@@ -81,7 +84,7 @@ class POS(MorphosyntacticFeature):
     symbol = auto()
     verb = auto()
     other = auto()
-    
+
 
 # Morphosyntactic Features.
 # The inventory of features represented here are those of the Universal Dependencies project.
@@ -90,6 +93,7 @@ class POS(MorphosyntacticFeature):
 # In particular, the list spatiotemporal cases is likely to grow over time.
 
 # Verbal features, related to +V categories.
+
 
 class VerbForm(MorphosyntacticFeature):
     """The inlectional type of the verb.  
@@ -370,6 +374,7 @@ class PrononimalType(MorphosyntacticFeature):
     relative = auto()
     total = auto()
 
+
 class AdpositionalType(MorphosyntacticFeature):
     """Defines the position of an adposition.
     see https://universaldependencies.org/u/feat/AdpType.html
@@ -444,7 +449,7 @@ class MorphosyntacticFeatureBundle:
         """
         >>> f1 = MorphosyntacticFeatureBundle(F.neg, N.pos, V.neg, Case.accusative)
         >>> f1.features
-        {<enum 'F'>: [<F.neg: 2>], <enum 'N'>: [<N.pos: 1>], <enum 'V'>: [<V.neg: 2>], <enum 'Case'>: [<Case.accusative: 2>]}
+        {F: [neg], N: [pos], V: [neg], Case: [accusative]}
         """
         self.features = {}
         for feature in features:
@@ -465,18 +470,18 @@ class MorphosyntacticFeatureBundle:
         Use dict-type syntax for accessing the values of features.
         >>> f1 = f(F.pos, N.pos)
         >>> f1[F]
-        [<F.pos: 1>]
+        [pos]
         >>> f1[V]
         Traceback (most recent call last):
-        cltk.core.exceptions.CLTKException: {<enum 'F'>: [<F.pos: 1>], <enum 'N'>: [<N.pos: 1>]} unspecified for <enum 'V'>
+        cltk.core.exceptions.CLTKException: {F: [pos], N: [pos]} unspecified for V
         """
         if not issubclass(feature_name, MorphosyntacticFeature):
             raise TypeError(str(feature_name) + " is not a morphosytactic feature")
-        
+
         if feature_name in self.features:
             return self.features[feature_name]
         else:
-            raise CLTKException(f'{self} unspecified for {feature_name}')
+            raise CLTKException(f"{self} unspecified for {feature_name}")
 
     def __setitem__(
         self,
@@ -488,11 +493,11 @@ class MorphosyntacticFeatureBundle:
         >>> f1 = f(F.pos)
         >>> f1[N] = N.neg
         >>> f1
-        {<enum 'F'>: [<F.pos: 1>], <enum 'N'>: [<N.neg: 2>]}
+        {F: [pos], N: [neg]}
         """
         if not issubclass(feature_name, MorphosyntacticFeature):
             raise TypeError(str(feature_name) + " is not a morphosyntactic feature")
-        
+
         if type(feature_values) is not list:
             feature_values = [feature_values]
 
@@ -551,13 +556,14 @@ class MorphosyntacticFeatureBundle:
 
 f = MorphosyntacticFeatureBundle
 
+
 def to_categorial(pos: int) -> "MorphosyntacticFeatureBundle":
     """Maps UD parts of speech to binary categorial feature bundles.
     In some cases these are underspecified, including empty bundles for interjections.
     >>> to_categorial(POS.adjective)
-    {<enum 'F'>: [<F.neg: 2>], <enum 'N'>: [<N.pos: 1>], <enum 'V'>: [<V.pos: 1>]}
+    {F: [neg], N: [pos], V: [pos]}
     >>> to_categorial(POS.particle)
-    {<enum 'F'>: [<F.pos: 1>]}
+    {F: [pos]}
     >>> to_categorial(POS.interjection)
     {}
     """
@@ -586,249 +592,229 @@ def to_categorial(pos: int) -> "MorphosyntacticFeatureBundle":
 
 from_ud_map = {
     # parts of speech
-    'POS': {
-        'ADJ': POS.adjective,
-        'ADP': POS.adposition,
-        'ADV': POS.adverb,
-        'AUX': POS.auxiliary,
-        'CCONJ': POS.coordinating_conjunction,
-        'DET': POS.determiner,
-        'INTJ': POS.interjection,
-        'NOUN': POS.noun,
-        'NUM': POS.numeral,
-        'PART': POS.particle,
-        'PRON': POS.pronoun,
-        'PROPN': POS.proper_noun,
-        'PUNCT': POS.punctuation,
-        'SCONJ': POS.subordinating_conjunction,
-        'SYM': POS.symbol,
-        'VERB': POS.verb,
-        'X': POS.other
+    "POS": {
+        "ADJ": POS.adjective,
+        "ADP": POS.adposition,
+        "ADV": POS.adverb,
+        "AUX": POS.auxiliary,
+        "CCONJ": POS.coordinating_conjunction,
+        "DET": POS.determiner,
+        "INTJ": POS.interjection,
+        "NOUN": POS.noun,
+        "NUM": POS.numeral,
+        "PART": POS.particle,
+        "PRON": POS.pronoun,
+        "PROPN": POS.proper_noun,
+        "PUNCT": POS.punctuation,
+        "SCONJ": POS.subordinating_conjunction,
+        "SYM": POS.symbol,
+        "VERB": POS.verb,
+        "X": POS.other,
     },
     # verbal features
-    'VerbForm': {
-        'Conv': VerbForm.converb,
-        'Fin': VerbForm.finite,
-        'Gdv': VerbForm.gerundive,
-        'Ger': VerbForm.gerund,
-        'Inf': VerbForm.infinitive,
-        'Part': VerbForm.participle,
-        'Sup': VerbForm.supine,
-        'Vnoun': VerbForm.masdar
+    "VerbForm": {
+        "Conv": VerbForm.converb,
+        "Fin": VerbForm.finite,
+        "Gdv": VerbForm.gerundive,
+        "Ger": VerbForm.gerund,
+        "Inf": VerbForm.infinitive,
+        "Part": VerbForm.participle,
+        "Sup": VerbForm.supine,
+        "Vnoun": VerbForm.masdar,
     },
-    'Mood': {
-        'Adm': Mood.admirative,
-        'Cnd': Mood.conditional,
-        'Des': Mood.desiderative,
-        'Imp': Mood.imperative,
-        'Ind': Mood.indicative,
-        'Jus': Mood.jussive,
-        'Nec': Mood.necessitative,
-        'Opt': Mood.optative,
-        'Pot': Mood.potential,
-        'Prp': Mood.purposive,
-        'Qot': Mood.quotative,
-        'Sub': Mood.subjunctive
+    "Mood": {
+        "Adm": Mood.admirative,
+        "Cnd": Mood.conditional,
+        "Des": Mood.desiderative,
+        "Imp": Mood.imperative,
+        "Ind": Mood.indicative,
+        "Jus": Mood.jussive,
+        "Nec": Mood.necessitative,
+        "Opt": Mood.optative,
+        "Pot": Mood.potential,
+        "Prp": Mood.purposive,
+        "Qot": Mood.quotative,
+        "Sub": Mood.subjunctive,
     },
-    'Tense': {
-        'Fut': Tense.future,
-        'Imp': Tense.imperfect,
-        'Past': Tense.past,
-        'Pqp': Tense.pluperfect,
-        'Pres': Tense.present
+    "Tense": {
+        "Fut": Tense.future,
+        "Imp": Tense.imperfect,
+        "Past": Tense.past,
+        "Pqp": Tense.pluperfect,
+        "Pres": Tense.present,
     },
-    'Aspect': {
-        'Hab': Aspect.habitual,
-        'Imp': Aspect.imperfective,
-        'Iter': Aspect.iterative,
-        'Perf': Aspect.perfective,
-        'Prog': Aspect.progressive,
-        'Prosp': Aspect.prospective
+    "Aspect": {
+        "Hab": Aspect.habitual,
+        "Imp": Aspect.imperfective,
+        "Iter": Aspect.iterative,
+        "Perf": Aspect.perfective,
+        "Prog": Aspect.progressive,
+        "Prosp": Aspect.prospective,
     },
-    'Voice': {
-        'Act': Voice.active,
-        'Antip': Voice.antipassive,
-        'Bfoc': Voice.beneficiary_focus,
-        'Lfoc': Voice.location_focus,
-        'Caus': Voice.causative,
-        'Dir': Voice.direct,
-        'Inv': Voice.inverse,
-        'Mid': Voice.middle,
-        'Pass': Voice.passive,
-        'Rcp': Voice.reciprocal,
+    "Voice": {
+        "Act": Voice.active,
+        "Antip": Voice.antipassive,
+        "Bfoc": Voice.beneficiary_focus,
+        "Lfoc": Voice.location_focus,
+        "Caus": Voice.causative,
+        "Dir": Voice.direct,
+        "Inv": Voice.inverse,
+        "Mid": Voice.middle,
+        "Pass": Voice.passive,
+        "Rcp": Voice.reciprocal,
     },
-    'Evident': {
-        'Fh': Evidentiality.first_hand,
-        'Nfh': Evidentiality.non_first_hand
+    "Evident": {"Fh": Evidentiality.first_hand, "Nfh": Evidentiality.non_first_hand},
+    "Polarity": {"Pos": Polarity.pos, "Neg": Polarity.neg},
+    "Person": {
+        "0": Person.zeroth,
+        "1": Person.first,
+        "2": Person.second,
+        "3": Person.third,
+        "4": Person.fourth,
     },
-    'Polarity': {
-        'Pos': Polarity.pos,
-        'Neg': Polarity.neg
+    "Polite": {
+        "Elev": Politeness.elevated,
+        "Form": Politeness.formal,
+        "Humb": Politeness.humble,
+        "Infm": Politeness.informal,
     },
-    'Person': {
-        '0': Person.zeroth,
-        '1': Person.first,
-        '2': Person.second,
-        '3': Person.third,
-        '4': Person.fourth
+    "Clusivity": {"Ex": Clusivity.exclusive, "In": Clusivity.inclusive},
+    # nominal
+    "Gender": {
+        "Com": Gender.common,
+        "Fem": Gender.feminine,
+        "Masc": Gender.masculine,
+        "Neut": Gender.neuter,
     },
-    'Polite': {
-        'Elev': Politeness.elevated,
-        'Form': Politeness.formal,
-        'Humb': Politeness.humble,
-        'Infm': Politeness.informal
+    "Animacy": {
+        "Anim": Animacy.animate,
+        "Hum": Animacy.human,
+        "Inan": Animacy.inanimate,
+        "Nhum": Animacy.non_human,
     },
-    'Clusivity': {
-        'Ex': Clusivity.exclusive,
-        'In': Clusivity.inclusive
+    "Number": {
+        "Coll": Number.collective,
+        "Count": Number.count_plural,
+        "Dual": Number.dual,
+        "Grpa": Number.greater_paucal,
+        "Grpl": Number.greater_plural,
+        "Inv": Number.inverse_number,
+        "Pauc": Number.paucal,
+        "Plur": Number.plural,
+        "Ptan": Number.plurale_tantum,
+        "Sing": Number.singular,
+        "Tri": Number.trial,
     },
-
-    #nominal
-    'Gender': {
-        'Com': Gender.common,
-        'Fem': Gender.feminine,
-        'Masc': Gender.masculine,
-        'Neut': Gender.neuter
-    },
-    'Animacy': {
-        'Anim': Animacy.animate,
-        'Hum': Animacy.human,
-        'Inan': Animacy.inanimate,
-        'Nhum': Animacy.non_human
-    },
-    'Number': {
-        'Coll': Number.collective,
-        'Count': Number.count_plural,
-        'Dual': Number.dual,
-        'Grpa': Number.greater_paucal,
-        'Grpl': Number.greater_plural,
-        'Inv': Number.inverse_number,
-        'Pauc': Number.paucal,
-        'Plur': Number.plural,
-        'Ptan': Number.plurale_tantum,
-        'Sing': Number.singular,
-        'Tri': Number.trial
-    },
-    'Case': {
-         # structural cases
-        'Nom': Case.nominative,
-        'Acc': Case.accusative,
-        'Erg': Case.ergative,
-        'Abs': Case.absolutive,
-
+    "Case": {
+        # structural cases
+        "Nom": Case.nominative,
+        "Acc": Case.accusative,
+        "Erg": Case.ergative,
+        "Abs": Case.absolutive,
         # oblique cases
-        'Abe': Case.abessive,
-        'Ben': Case.befefactive,
-        'Caus': Case.causative,
-        'Cmp': Case.comparative,
-        'Cns': Case.considerative,
-        'Com': Case.comitative,
-        'Dat': Case.dative,
-        'Dis': Case.distributive,
-        'Equ': Case.equative,
-        'Gen': Case.genitive,
-        'Ins': Case.instrumental,
-        'Par': Case.partitive,
-        'Voc': Case.vocative,
-
+        "Abe": Case.abessive,
+        "Ben": Case.befefactive,
+        "Caus": Case.causative,
+        "Cmp": Case.comparative,
+        "Cns": Case.considerative,
+        "Com": Case.comitative,
+        "Dat": Case.dative,
+        "Dis": Case.distributive,
+        "Equ": Case.equative,
+        "Gen": Case.genitive,
+        "Ins": Case.instrumental,
+        "Par": Case.partitive,
+        "Voc": Case.vocative,
         # spatiotemporal cases
-        'Abl': Case.ablative,
-        'Add': Case.additive,
-        'Ade': Case.adessive,
-        'All': Case.allative,
-        'Del': Case.delative,
-        'Ela': Case.elative,
-        'Ess': Case.essive,
-        'Ill': Case.illative,
-        'Ine': Case.inessive,
-        'Lat': Case.lative,
-        'Loc': Case.locative,
-        'Per': Case.perlative,
-        'Sub': Case.sublative,
-        'Sup': Case.superessive,
-        'Ter': Case.terminative,
-        'Tem': Case.temporal,
-        'Tra': Case.translative
+        "Abl": Case.ablative,
+        "Add": Case.additive,
+        "Ade": Case.adessive,
+        "All": Case.allative,
+        "Del": Case.delative,
+        "Ela": Case.elative,
+        "Ess": Case.essive,
+        "Ill": Case.illative,
+        "Ine": Case.inessive,
+        "Lat": Case.lative,
+        "Loc": Case.locative,
+        "Per": Case.perlative,
+        "Sub": Case.sublative,
+        "Sup": Case.superessive,
+        "Ter": Case.terminative,
+        "Tem": Case.temporal,
+        "Tra": Case.translative,
     },
-    'Definite': {
-        'Com': Definiteness.complex,
-        'Cons': Definiteness.construct_state,
-        'Def': Definiteness.definite,
-        'Ind': Definiteness.indefinite,
-        'Spec': Definiteness.specific_indefinite
+    "Definite": {
+        "Com": Definiteness.complex,
+        "Cons": Definiteness.construct_state,
+        "Def": Definiteness.definite,
+        "Ind": Definiteness.indefinite,
+        "Spec": Definiteness.specific_indefinite,
     },
-    'Degree': {
-        'Abs': Degree.absolute_superlative,
-        'Cmp': Degree.comparative,
-        'Equ': Degree.equative,
-        'Pos': Degree.positive,
-        'Sup': Degree.superlative
+    "Degree": {
+        "Abs": Degree.absolute_superlative,
+        "Cmp": Degree.comparative,
+        "Equ": Degree.equative,
+        "Pos": Degree.positive,
+        "Sup": Degree.superlative,
     },
-
     # other lexical
-    'PronType': {
-        'Art': PrononimalType.article,
-        'Dem': PrononimalType.demonstrative,
-        'Emp': PrononimalType.emphatic,
-        'Exc': PrononimalType.exclamative,
-        'Ind': PrononimalType.indefinite,
-        'Int': PrononimalType.interrogative,
-        'Neg': PrononimalType.negative,
-        'Prs': PrononimalType.personal,
-        'Rcp': PrononimalType.reciprocal,
-        'Rel': PrononimalType.relative,
-        'Tot': PrononimalType.total
+    "PronType": {
+        "Art": PrononimalType.article,
+        "Dem": PrononimalType.demonstrative,
+        "Emp": PrononimalType.emphatic,
+        "Exc": PrononimalType.exclamative,
+        "Ind": PrononimalType.indefinite,
+        "Int": PrononimalType.interrogative,
+        "Neg": PrononimalType.negative,
+        "Prs": PrononimalType.personal,
+        "Rcp": PrononimalType.reciprocal,
+        "Rel": PrononimalType.relative,
+        "Tot": PrononimalType.total,
     },
-    'AdpType': {
-        'Prep': AdpositionalType.preposition,
-        'Post': AdpositionalType.postposition,
-        'Circ': AdpositionalType.circumposition,
-        'Voc': AdpositionalType.vocalized_adposition
+    "AdpType": {
+        "Prep": AdpositionalType.preposition,
+        "Post": AdpositionalType.postposition,
+        "Circ": AdpositionalType.circumposition,
+        "Voc": AdpositionalType.vocalized_adposition,
     },
-    'NumType': {
-        'Card': Numeral.cardinal,
-        'Dist': Numeral.distributive,
-        'Frac': Numeral.fractional,
-        'Mult': Numeral.multiplicative,
-        'Ord': Numeral.ordinal,
-        'Range': Numeral.range,
-        'Sets': Numeral.sets
+    "NumType": {
+        "Card": Numeral.cardinal,
+        "Dist": Numeral.distributive,
+        "Frac": Numeral.fractional,
+        "Mult": Numeral.multiplicative,
+        "Ord": Numeral.ordinal,
+        "Range": Numeral.range,
+        "Sets": Numeral.sets,
     },
-    'Poss': {
-        'Yes': Possessive
-    },
-    'Reflex': {
-        'Yes': Reflexive
-    },
-    'Foreign': {
-        'Yes': Foreign
-    },
-    'Abbr': {
-        'Yes': Abbreviation
-    },
-    'Typo': {
-        'Yes': Typo
-    }
+    "Poss": {"Yes": Possessive},
+    "Reflex": {"Yes": Reflexive},
+    "Foreign": {"Yes": Foreign},
+    "Abbr": {"Yes": Abbreviation},
+    "Typo": {"Yes": Typo},
 }
+
 
 def from_ud(feature_name: str, feature_value: str) -> MorphosyntacticFeature:
     """For a given Universal Dependencies feature name and value,
     return the appropriate feature class/value.
     >>> from_ud('Case', 'Abl')
-    <Case.ablative: 18>
+    ablative
     >>> from_ud('Abbr', 'Yes')
-    <enum 'Abbreviation'>
+    Abbreviation
     >>> from_ud('PronType', 'Ind')
-    <PrononimalType.indefinite: 5>
+    indefinite
     """
     if feature_name in from_ud_map:
         feature_map = from_ud_map[feature_name]
     else:
-        raise CLTKException(f'{feature_name}: Unrecognized UD feature name')
-    
-    values = feature_value.split(',')
+        raise CLTKException(f"{feature_name}: Unrecognized UD feature name")
+
+    values = feature_value.split(",")
     for value in values:
         if value in feature_map:
             return feature_map[value]
         else:
-            raise CLTKException(f'{value}: Unrecognized value for UD feature {feature_name}')
+            raise CLTKException(
+                f"{value}: Unrecognized value for UD feature {feature_name}"
+            )

--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -1,7 +1,9 @@
 """A module for representing universal morphosyntactic feature bundles."""
 
 from enum import IntEnum, auto
-from typing import List, Type
+from typing import List, Type, Union
+
+from cltk.core.exceptions import CLTKException
 
 __author__ = ["John Stewart <free-variation>"]
 
@@ -35,7 +37,7 @@ class CategorialFeature(BinaryFeature):
 
 
 # The following are the traditional categorial features [+/-N, +/-V] of generative linguistics,
-# extended with the +/-F(unctional) feature as developed by Fukui (1986).
+# augmented with the +/-F(unctional) feature as developed by Fukui (1986).
 # See Fukui, N. 1986. A theory of category projection and its applications. Ph.D. dissertation, MIT.
 # Though simplistic by today's standards, the scheme is more-or-less sufficient to represent
 # the parts of speech of the Universal Dependencies project (https://universaldependencies.org/u/pos/index.html).
@@ -57,6 +59,30 @@ class F(CategorialFeature):
     neg = auto()
 
 
+class POS(MorphosyntacticFeature):
+    """The POS "feature" represents the list of syntactic categories published by the UD project.
+    See https://universaldependencies.org/u/pos/index.html
+    """
+
+    adjective = auto()
+    adposition = auto()
+    adverb = auto()
+    auxiliary = auto()
+    coordinating_conjunction = auto()
+    determiner = auto()
+    interjection = auto()
+    noun = auto()
+    numeral = auto()
+    particle = auto()
+    pronoun = auto()
+    proper_noun = auto()
+    punctuation = auto()
+    subordinating_conjunction = auto()
+    symbol = auto()
+    verb = auto()
+    other = auto()
+    
+
 # Morphosyntactic Features.
 # The inventory of features represented here are those of the Universal Dependencies project.
 # See https://universaldependencies.org/u/feat/index.html
@@ -64,7 +90,6 @@ class F(CategorialFeature):
 # In particular, the list spatiotemporal cases is likely to grow over time.
 
 # Verbal features, related to +V categories.
-
 
 class VerbForm(MorphosyntacticFeature):
     """The inlectional type of the verb.  
@@ -133,6 +158,8 @@ class Voice(MorphosyntacticFeature):
 
     active = auto()
     antipassive = auto()
+    beneficiary_focus = auto()
+    location_focus = auto()
     causative = auto()
     direct = auto()
     inverse = auto()
@@ -165,11 +192,11 @@ class Person(MorphosyntacticFeature):
     # see https://universaldependencies.org/u/feat/Person.html
     """
 
-    zero = auto()
-    one = auto()
-    two = auto()
-    three = auto()
-    four = auto()
+    zeroth = auto()
+    first = auto()
+    second = auto()
+    third = auto()
+    fourth = auto()
 
 
 class Politeness(MorphosyntacticFeature):
@@ -273,7 +300,7 @@ class Animacy(MorphosyntacticFeature):
 
     animate = auto()
     human = auto()
-    inaninate = auto()
+    inanimate = auto()
     non_human = auto()
 
 
@@ -343,6 +370,16 @@ class PrononimalType(MorphosyntacticFeature):
     relative = auto()
     total = auto()
 
+class AdpositionalType(MorphosyntacticFeature):
+    """Defines the position of an adposition.
+    see https://universaldependencies.org/u/feat/AdpType.html
+    """
+
+    preposition = auto()
+    postposition = auto()
+    circumposition = auto()
+    vocalized_adposition = auto()
+
 
 class Possessive(PrivativeFeature):
     """Is this nominal form marked as a possessive?
@@ -382,7 +419,7 @@ class Foreign(PrivativeFeature):
     pass
 
 
-class Abbr(PrivativeFeature):
+class Abbreviation(PrivativeFeature):
     """Is this word an abbreviation?
     see https://universaldependencies.org/u/feat/Abbr.html
     """
@@ -407,7 +444,7 @@ class MorphosyntacticFeatureBundle:
         """
         >>> f1 = MorphosyntacticFeatureBundle(F.neg, N.pos, V.neg, Case.accusative)
         >>> f1.features
-        {<enum 'F'>: <F.neg: 2>, <enum 'N'>: <N.pos: 1>, <enum 'V'>: <V.neg: 2>, <enum 'Case'>: <Case.accusative: 2>}
+        {<enum 'F'>: [<F.neg: 2>], <enum 'N'>: [<N.pos: 1>], <enum 'V'>: [<V.neg: 2>], <enum 'Case'>: [<Case.accusative: 2>]}
         """
         self.features = {}
         for feature in features:
@@ -416,41 +453,54 @@ class MorphosyntacticFeatureBundle:
             ):
                 self.features[feature] = Underspecified
             else:
-                self.features[type(feature)] = feature
+                if type(feature) in self.features:
+                    self.features[type(feature)].append(feature)
+                else:
+                    self.features[type(feature)] = [feature]
 
     def __getitem__(
         self, feature_name: Type[MorphosyntacticFeature]
-    ) -> MorphosyntacticFeature:
+    ) -> List[MorphosyntacticFeature]:
         """
         Use dict-type syntax for accessing the values of features.
         >>> f1 = f(F.pos, N.pos)
         >>> f1[F]
-        <F.pos: 1>
+        [<F.pos: 1>]
         >>> f1[V]
         Traceback (most recent call last):
-        KeyError: <enum 'V'>
+        cltk.core.exceptions.CLTKException: {<enum 'F'>: [<F.pos: 1>], <enum 'N'>: [<N.pos: 1>]} unspecified for <enum 'V'>
         """
         if not issubclass(feature_name, MorphosyntacticFeature):
             raise TypeError(str(feature_name) + " is not a morphosytactic feature")
-        return self.features[feature_name]
+        
+        if feature_name in self.features:
+            return self.features[feature_name]
+        else:
+            raise CLTKException(f'{self} unspecified for {feature_name}')
 
     def __setitem__(
         self,
         feature_name: Type[MorphosyntacticFeature],
-        feature_value: MorphosyntacticFeature,
+        feature_values: Union[MorphosyntacticFeature, List[MorphosyntacticFeature]],
     ) -> "MorphosyntacticFeatureBundle":
         """
         Use dict-type syntax to set the value of features.
         >>> f1 = f(F.pos)
         >>> f1[N] = N.neg
         >>> f1
-        {<enum 'F'>: <F.pos: 1>, <enum 'N'>: <N.neg: 2>}
+        {<enum 'F'>: [<F.pos: 1>], <enum 'N'>: [<N.neg: 2>]}
         """
         if not issubclass(feature_name, MorphosyntacticFeature):
             raise TypeError(str(feature_name) + " is not a morphosyntactic feature")
-        if feature_value is not None and type(feature_value) != feature_name:
-            raise TypeError(str(feature_value) + " is not a " + str(feature_name))
-        self.features[feature_name] = feature_value
+        
+        if type(feature_values) is not list:
+            feature_values = [feature_values]
+
+        for value in feature_values:
+            if value is not None and type(value) != feature_name:
+                raise TypeError(str(value) + " is not a " + str(feature_name))
+
+        self.features[feature_name] = feature_values
         return self
 
     def underspecify(self, feature_name: Type[MorphosyntacticFeature]) -> None:
@@ -500,3 +550,285 @@ class MorphosyntacticFeatureBundle:
 
 
 f = MorphosyntacticFeatureBundle
+
+def to_categorial(pos: int) -> "MorphosyntacticFeatureBundle":
+    """Maps UD parts of speech to binary categorial feature bundles.
+    In some cases these are underspecified, including empty bundles for interjections.
+    >>> to_categorial(POS.adjective)
+    {<enum 'F'>: [<F.neg: 2>], <enum 'N'>: [<N.pos: 1>], <enum 'V'>: [<V.pos: 1>]}
+    >>> to_categorial(POS.particle)
+    {<enum 'F'>: [<F.pos: 1>]}
+    >>> to_categorial(POS.interjection)
+    {}
+    """
+
+    if pos == POS.adjective or pos == POS.adverb:
+        return f(F.neg, N.pos, V.pos)
+    elif pos == POS.adposition:
+        return f(F.pos, N.neg, V.neg)
+    elif pos == POS.auxiliary:
+        return f(F.pos, N.neg, V.pos)
+    elif (
+        pos == POS.coordinating_conjunction
+        or pos == POS.subordinating_conjunction
+        or pos == POS.particle
+    ):
+        return f(F.pos)
+    elif pos == POS.determiner or pos == POS.pronoun or pos == POS.numeral:
+        return f(F.pos, N.pos, V.neg)
+    elif pos == POS.noun or pos == POS.proper_noun:
+        return f(F.neg, N.pos, V.neg)
+    elif pos == POS.verb:
+        return f(F.neg, N.neg, V.pos)
+    else:
+        return f()
+
+
+from_ud_map = {
+    # parts of speech
+    'POS': {
+        'ADJ': POS.adjective,
+        'ADP': POS.adposition,
+        'ADV': POS.adverb,
+        'AUX': POS.auxiliary,
+        'CCONJ': POS.coordinating_conjunction,
+        'DET': POS.determiner,
+        'INTJ': POS.interjection,
+        'NOUN': POS.noun,
+        'NUM': POS.numeral,
+        'PART': POS.particle,
+        'PRON': POS.pronoun,
+        'PROPN': POS.proper_noun,
+        'PUNCT': POS.punctuation,
+        'SCONJ': POS.subordinating_conjunction,
+        'SYM': POS.symbol,
+        'VERB': POS.verb,
+        'X': POS.other
+    },
+    # verbal features
+    'VerbForm': {
+        'Conv': VerbForm.converb,
+        'Fin': VerbForm.finite,
+        'Gdv': VerbForm.gerundive,
+        'Ger': VerbForm.gerund,
+        'Inf': VerbForm.infinitive,
+        'Part': VerbForm.participle,
+        'Sup': VerbForm.supine,
+        'Vnoun': VerbForm.masdar
+    },
+    'Mood': {
+        'Adm': Mood.admirative,
+        'Cnd': Mood.conditional,
+        'Des': Mood.desiderative,
+        'Imp': Mood.imperative,
+        'Ind': Mood.indicative,
+        'Jus': Mood.jussive,
+        'Nec': Mood.necessitative,
+        'Opt': Mood.optative,
+        'Pot': Mood.potential,
+        'Prp': Mood.purposive,
+        'Qot': Mood.quotative,
+        'Sub': Mood.subjunctive
+    },
+    'Tense': {
+        'Fut': Tense.future,
+        'Imp': Tense.imperfect,
+        'Past': Tense.past,
+        'Pqp': Tense.pluperfect,
+        'Pres': Tense.present
+    },
+    'Aspect': {
+        'Hab': Aspect.habitual,
+        'Imp': Aspect.imperfective,
+        'Iter': Aspect.iterative,
+        'Perf': Aspect.perfective,
+        'Prog': Aspect.progressive,
+        'Prosp': Aspect.prospective
+    },
+    'Voice': {
+        'Act': Voice.active,
+        'Antip': Voice.antipassive,
+        'Bfoc': Voice.beneficiary_focus,
+        'Lfoc': Voice.location_focus,
+        'Caus': Voice.causative,
+        'Dir': Voice.direct,
+        'Inv': Voice.inverse,
+        'Mid': Voice.middle,
+        'Pass': Voice.passive,
+        'Rcp': Voice.reciprocal,
+    },
+    'Evident': {
+        'Fh': Evidentiality.first_hand,
+        'Nfh': Evidentiality.non_first_hand
+    },
+    'Polarity': {
+        'Pos': Polarity.pos,
+        'Neg': Polarity.neg
+    },
+    'Person': {
+        '0': Person.zeroth,
+        '1': Person.first,
+        '2': Person.second,
+        '3': Person.third,
+        '4': Person.fourth
+    },
+    'Polite': {
+        'Elev': Politeness.elevated,
+        'Form': Politeness.formal,
+        'Humb': Politeness.humble,
+        'Infm': Politeness.informal
+    },
+    'Clusivity': {
+        'Ex': Clusivity.exclusive,
+        'In': Clusivity.inclusive
+    },
+
+    #nominal
+    'Gender': {
+        'Com': Gender.common,
+        'Fem': Gender.feminine,
+        'Masc': Gender.masculine,
+        'Neut': Gender.neuter
+    },
+    'Animacy': {
+        'Anim': Animacy.animate,
+        'Hum': Animacy.human,
+        'Inan': Animacy.inanimate,
+        'Nhum': Animacy.non_human
+    },
+    'Number': {
+        'Coll': Number.collective,
+        'Count': Number.count_plural,
+        'Dual': Number.dual,
+        'Grpa': Number.greater_paucal,
+        'Grpl': Number.greater_plural,
+        'Inv': Number.inverse_number,
+        'Pauc': Number.paucal,
+        'Plur': Number.plural,
+        'Ptan': Number.plurale_tantum,
+        'Sing': Number.singular,
+        'Tri': Number.trial
+    },
+    'Case': {
+         # structural cases
+        'Nom': Case.nominative,
+        'Acc': Case.accusative,
+        'Erg': Case.ergative,
+        'Abs': Case.absolutive,
+
+        # oblique cases
+        'Abe': Case.abessive,
+        'Ben': Case.befefactive,
+        'Caus': Case.causative,
+        'Cmp': Case.comparative,
+        'Cns': Case.considerative,
+        'Com': Case.comitative,
+        'Dat': Case.dative,
+        'Dis': Case.distributive,
+        'Equ': Case.equative,
+        'Gen': Case.genitive,
+        'Ins': Case.instrumental,
+        'Par': Case.partitive,
+        'Voc': Case.vocative,
+
+        # spatiotemporal cases
+        'Abl': Case.ablative,
+        'Add': Case.additive,
+        'Ade': Case.adessive,
+        'All': Case.allative,
+        'Del': Case.delative,
+        'Ela': Case.elative,
+        'Ess': Case.essive,
+        'Ill': Case.illative,
+        'Ine': Case.inessive,
+        'Lat': Case.lative,
+        'Loc': Case.locative,
+        'Per': Case.perlative,
+        'Sub': Case.sublative,
+        'Sup': Case.superessive,
+        'Ter': Case.terminative,
+        'Tem': Case.temporal,
+        'Tra': Case.translative
+    },
+    'Definite': {
+        'Com': Definiteness.complex,
+        'Cons': Definiteness.construct_state,
+        'Def': Definiteness.definite,
+        'Ind': Definiteness.indefinite,
+        'Spec': Definiteness.specific_indefinite
+    },
+    'Degree': {
+        'Abs': Degree.absolute_superlative,
+        'Cmp': Degree.comparative,
+        'Equ': Degree.equative,
+        'Pos': Degree.positive,
+        'Sup': Degree.superlative
+    },
+
+    # other lexical
+    'PronType': {
+        'Art': PrononimalType.article,
+        'Dem': PrononimalType.demonstrative,
+        'Emp': PrononimalType.emphatic,
+        'Exc': PrononimalType.exclamative,
+        'Ind': PrononimalType.indefinite,
+        'Int': PrononimalType.interrogative,
+        'Neg': PrononimalType.negative,
+        'Prs': PrononimalType.personal,
+        'Rcp': PrononimalType.reciprocal,
+        'Rel': PrononimalType.relative,
+        'Tot': PrononimalType.total
+    },
+    'AdpType': {
+        'Prep': AdpositionalType.preposition,
+        'Post': AdpositionalType.postposition,
+        'Circ': AdpositionalType.circumposition,
+        'Voc': AdpositionalType.vocalized_adposition
+    },
+    'NumType': {
+        'Card': Numeral.cardinal,
+        'Dist': Numeral.distributive,
+        'Frac': Numeral.fractional,
+        'Mult': Numeral.multiplicative,
+        'Ord': Numeral.ordinal,
+        'Range': Numeral.range,
+        'Sets': Numeral.sets
+    },
+    'Poss': {
+        'Yes': Possessive
+    },
+    'Reflex': {
+        'Yes': Reflexive
+    },
+    'Foreign': {
+        'Yes': Foreign
+    },
+    'Abbr': {
+        'Yes': Abbreviation
+    },
+    'Typo': {
+        'Yes': Typo
+    }
+}
+
+def from_ud(feature_name: str, feature_value: str) -> MorphosyntacticFeature:
+    """For a given Universal Dependencies feature name and value,
+    return the appropriate feature class/value.
+    >>> from_ud('Case', 'Abl')
+    <Case.ablative: 18>
+    >>> from_ud('Abbr', 'Yes')
+    <enum 'Abbreviation'>
+    >>> from_ud('PronType', 'Ind')
+    <PrononimalType.indefinite: 5>
+    """
+    if feature_name in from_ud_map:
+        feature_map = from_ud_map[feature_name]
+    else:
+        raise CLTKException(f'{feature_name}: Unrecognized UD feature name')
+    
+    values = feature_value.split(',')
+    for value in values:
+        if value in feature_map:
+            return feature_map[value]
+        else:
+            raise CLTKException(f'{value}: Unrecognized value for UD feature {feature_name}')

--- a/src/cltk/nlp.py
+++ b/src/cltk/nlp.py
@@ -110,7 +110,10 @@ class NLP:
         >>> isinstance(cltk_doc, Doc)
         True
         >>> cltk_doc.words[0] # doctest: +ELLIPSIS
-        Word(index_char_start=None, index_char_stop=None, index_token=0, index_sentence=0, string='Gallia', pos='NOUN', lemma='mallis', stem=None, scansion=None, xpos='A1|grn1|casA|gen2', upos='NOUN', dependency_relation='nsubj', governor=3, features={'Case': 'Nom', 'Degree': 'Pos', 'Gender': 'Fem', 'Number': 'Sing'}, embedding=..., stop=False, named_entity=True, syllables=None, phonetic_transcription=None)
+        Word(index_char_start=None, index_char_stop=None, index_token=0, index_sentence=0, string='Gallia', pos=noun, \
+lemma='mallis', stem=None, scansion=None, xpos='A1|grn1|casA|gen2', upos='NOUN', dependency_relation='nsubj', governor=3, \
+features={Case: [nominative], Degree: [positive], Gender: [feminine], Number: [singular]}, category={F: [neg], N: [pos], V: [neg]}, \
+embedding=..., stop=False, named_entity=True, syllables=None, phonetic_transcription=None)
         """
         doc = Doc(language=self.language.iso_639_3_code, raw=text)
 

--- a/src/cltk/phonology/orthophonology.py
+++ b/src/cltk/phonology/orthophonology.py
@@ -14,11 +14,14 @@ Based on many ideas in cltk.phonology.non.utils by Clément Besnier <clem@clemen
 
 import re
 from copy import deepcopy
-from enum import IntEnum, auto
+from enum import auto
+from typing import Union
+
+from cltk.utils.utils import CLTKEnum
 
 # The list of features and their values are from the IPA charts.
 # Features for non-pulmonic consonants (e.g. clicks, implosives) are not yet provided.
-from typing import Union
+
 
 __author__ = [
     "John Stewart <johnstewart@aya.yale.edu>",
@@ -29,7 +32,7 @@ __author__ = [
 # ------------------- Phonological Features -------------------
 
 
-class PhonologicalFeature(IntEnum):
+class PhonologicalFeature(CLTKEnum):
     def __sub__(self, other):
         return make_phoneme(self) - other
 
@@ -44,9 +47,6 @@ class PhonologicalFeature(IntEnum):
 
     def matches(self, other):
         return make_phoneme(self).matches(other)
-
-    def __eq__(self, other):
-        return False if type(self) != type(other) else IntEnum.__eq__(self, other)
 
     def __floordiv__(self, other):
         return make_phoneme(self) // other

--- a/src/cltk/tag/pos.py
+++ b/src/cltk/tag/pos.py
@@ -42,7 +42,6 @@ TAGGERS = {
 }
 
 
-
 class POSTag:
     """Tag words' parts-of-speech."""
 

--- a/src/cltk/utils/utils.py
+++ b/src/cltk/utils/utils.py
@@ -4,10 +4,24 @@ import os
 import sys
 from contextlib import contextmanager
 from distutils.util import strtobool
+from enum import EnumMeta, IntEnum
 from typing import Any, Dict, List, Optional, Union
 
 import requests
 from tqdm import tqdm
+
+
+class CLTKEnumMeta(EnumMeta):
+    def __repr__(cls):
+        return cls.__name__
+
+
+class CLTKEnum(IntEnum, metaclass=CLTKEnumMeta):
+    def __repr__(self):
+        return f"{self._name_}"
+
+    def __eq__(self, other):
+        return False if type(self) != type(other) else IntEnum.__eq__(self, other)
 
 
 def file_exists(file_path: str, is_dir: bool = False) -> bool:


### PR DESCRIPTION
The `cltk.morphology.morphosyntax` module defines a long list of constants, represented as [Python enumerations](https://docs.python.org/3/library/enum.html), that represent *at least* the features and values published by the [Universal Dependencies](https://universaldependencies.org/) project.  

Stanza pipelines for the most part return words annotated with UD features (though this is treebank-dependent).  This PR: 

1.  transforms the strings of feature names and values returned by Stanza for each word to CLTK `MorphosyntacticFeature` objects;
2.  replaces POS string attributes with constants of the `POS` enumeration;
3.  adds a `category` attribute to `Word` objects, representing the part of speech of the word in terms of binary categorial features, F(unctional), N(ominal), V(erbal).

Doctests have been updated.



