### PR TITLE
print non-match of feature instead of error

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,6 +29,8 @@ To install from source, clone the Git repository and run:
 
 .. code-block::
 
+   $ git clone https://github.com/cltk/cltk.git
+   $ cd cltk/
    $ make install
 
 

--- a/notebooks/CLTK Demonstration.ipynb
+++ b/notebooks/CLTK Demonstration.ipynb
@@ -27,16 +27,16 @@
     "\n",
     "Full documentation available at <https://docs.cltk.org/en/latest/cltk.html#cltk.nlp.NLP>.\n",
     "\n",
-    "Note that there is a large amoung of code from this project's first six years (v. `0.1`), not all of which has been or will be moved over to this v. `1.0`. Docs for `0.1` still available at [https://docs.cltk.org](https://docs.cltk.org/en/latest/) and tutorial notebooks at [https://github.com/cltk/tutorials](https://github.com/cltk/tutorials)."
+    "Note that there is a large amoung of code from this project's first six years (v. `0.1`), not all of which has been or will be moved over to this v. `1.0`. Docs for `0.1` still available at [https://legacy.cltk.org](https://legacy.cltk.org/) and tutorial notebooks at [https://github.com/cltk/tutorials](https://github.com/cltk/tutorials)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Install pre-release of CLTK <a name=\"install\"></a>\n",
+    "# Install CLTK <a name=\"install\"></a>\n",
     "\n",
-    "This notebook comes from <https://github.com/cltk/cltk/tree/dev/notebooks>. For full instructions on installing the CLTK are available at <https://docs.cltk.org/en/latest/installation.html>."
+    "This notebook comes from <https://github.com/cltk/cltk/tree/master/notebooks>. For full instructions on installing the CLTK are available at <https://docs.cltk.org/en/latest/installation.html>."
    ]
   },
   {
@@ -48,7 +48,7 @@
     "## Requires Python 3.7, 3.8, 3.9 on a POSIX-compliant OS\n",
     "\n",
     "## The latest published beta:\n",
-    "# !pip install --pre cltk"
+    "# !pip install cltk"
    ]
   },
   {
@@ -86,8 +86,8 @@
      "text": [
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0\n",
-      "100  899k  100  899k    0     0   370k      0  0:00:02  0:00:02 --:--:-- 5469k\n"
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n",
+      "100  899k  100  899k    0     0   548k      0  0:00:01  0:00:01 --:--:-- 1031k\n"
      ]
     }
    ],
@@ -109,8 +109,8 @@
      "text": [
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n",
-      "100  899k  100  899k    0     0   692k      0  0:00:01  0:00:01 --:--:-- 1660k\n"
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0-- --:--:--     0\n",
+      "100  899k  100  899k    0     0   659k      0  0:00:01  0:00:01 --:--:-- 2298k\n"
      ]
     }
    ],
@@ -219,7 +219,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "‎𐤀 CLTK version 'cltk 1.0.0b10'.\n",
+      "‎𐤀 CLTK version '1.0.7'.\n",
       "Pipeline for language 'Latin' (ISO: 'lat'): `LatinNormalizeProcess`, `LatinStanzaProcess`, `LatinEmbeddingsProcess`, `StopsProcess`, `LatinNERProcess`, `LatinLexiconProcess`.\n"
      ]
     }
@@ -257,8 +257,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 21s, sys: 10 s, total: 1min 31s\n",
-      "Wall time: 1min 24s\n"
+      "CPU times: user 1min 23s, sys: 9.83 s, total: 1min 33s\n",
+      "Wall time: 1min 27s\n"
      ]
     }
    ],
@@ -1294,7 +1294,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "‎𐤀 CLTK version 'cltk 1.0.0b10'.\n",
+      "‎𐤀 CLTK version '1.0.7'.\n",
       "Pipeline for language 'Ancient Greek' (ISO: 'grc'): `GreekNormalizeProcess`, `GreekStanzaProcess`, `GreekEmbeddingsProcess`, `StopsProcess`, `GreekNERProcess`.\n"
      ]
     }
@@ -1312,8 +1312,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 41.5 s, sys: 8.31 s, total: 49.9 s\n",
-      "Wall time: 43.3 s\n"
+      "CPU times: user 40.1 s, sys: 7.34 s, total: 47.4 s\n",
+      "Wall time: 41.2 s\n"
      ]
     }
    ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cltk"
-version = "1.0.6"
+version = "1.0.7"
 description = "The Classical Language Toolkit"
 license = "MIT"
 authors = ["Kyle P. Johnson <kyle@kyle-p-johnson.com>", "Patrick J. Burns <patrick@diyclassics.org>", "John Stewart <johnstewart@aya.yale.edu>", "Todd Cook <todd.g.cook@gmail.com>", "Clément Besnier <https://github.com/clemsciences>", "William J. B. Mattingly <https://github.com/wjbmattingly>"]

--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -1,6 +1,6 @@
 """A module for representing universal morphosyntactic feature bundles."""
 
-from typing import Dict, List, Tuple, Type, Union
+from typing import Dict, List, Tuple, Type, Optional, Union
 
 from cltk.core.exceptions import CLTKException
 from cltk.morphology.universal_dependencies_features import *

--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -425,7 +425,8 @@ def from_ud(feature_name: str, feature_value: str) -> Optional[MorphosyntacticFe
         feature_map = from_ud_map[feature_name]
     else:
         msg = f"{feature_name}: Unrecognized UD feature name"
-        raise CLTKException(msg)
+        print("From `from_ud():`", msg)
+        # raise CLTKException(msg)
         return None
 
     values = feature_value.split(",")

--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -1,6 +1,6 @@
 """A module for representing universal morphosyntactic feature bundles."""
 
-from typing import List, Tuple, Type, Union
+from typing import Dict, List, Tuple, Type, Union
 
 from cltk.core.exceptions import CLTKException
 from cltk.morphology.universal_dependencies_features import *
@@ -176,7 +176,7 @@ def to_categorial(pos: int) -> "MorphosyntacticFeatureBundle":
         return f()
 
 
-from_ud_map = {
+from_ud_map: Dict[str, Dict[str, MorphosyntacticFeature]] = {
     # parts of speech
     "POS": {
         "ADJ": POS.adjective,
@@ -411,7 +411,7 @@ from_ud_map = {
 }
 
 
-def from_ud(feature_name: str, feature_value: str) -> MorphosyntacticFeature:
+def from_ud(feature_name: str, feature_value: str) -> Optional[MorphosyntacticFeature]:
     """For a given Universal Dependencies feature name and value,
     return the appropriate feature class/value.
     >>> from_ud('Case', 'Abl')
@@ -424,7 +424,9 @@ def from_ud(feature_name: str, feature_value: str) -> MorphosyntacticFeature:
     if feature_name in from_ud_map:
         feature_map = from_ud_map[feature_name]
     else:
-        raise CLTKException(f"{feature_name}: Unrecognized UD feature name")
+        msg = f"{feature_name}: Unrecognized UD feature name"
+        raise CLTKException(msg)
+        return None
 
     values = feature_value.split(",")
     for value in values:


### PR DESCRIPTION
If fleeting on Livy text, don't know why. this should print and move on