### PR TITLE
fix for #1082

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,5 +143,5 @@ html_theme = "alabaster"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_favicon = 'favicon-32x32.png'
+html_favicon = "favicon-32x32.png"
 # https://alabaster.readthedocs.io/en/latest/installation.html

--- a/src/cltk/dependency/processes.py
+++ b/src/cltk/dependency/processes.py
@@ -98,9 +98,7 @@ embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcrip
                     upos=stanza_word.upos,
                     lemma=stanza_word.lemma,
                     dependency_relation=stanza_word.deprel,
-                    governor=stanza_word.head - 1
-                    if stanza_word.head
-                    else -1,  # note: if val becomes ``-1`` then no governor, ie word is root; ``fro`` gives None sometimes, what does this mean?
+                    governor=stanza_word.head - 1 if stanza_word.head else -1  # note: if val becomes ``-1`` then no governor, ie word is root
                 )  # type: Word
 
                 # convert UD features to the normalized CLTK features

--- a/src/cltk/dependency/processes.py
+++ b/src/cltk/dependency/processes.py
@@ -98,7 +98,9 @@ embedding=None, stop=None, named_entity=None, syllables=None, phonetic_transcrip
                     upos=stanza_word.upos,
                     lemma=stanza_word.lemma,
                     dependency_relation=stanza_word.deprel,
-                    governor=stanza_word.head - 1 if stanza_word.head else -1  # note: if val becomes ``-1`` then no governor, ie word is root
+                    governor=stanza_word.head - 1
+                    if stanza_word.head
+                    else -1,  # note: if val becomes ``-1`` then no governor, ie word is root
                 )  # type: Word
 
                 # convert UD features to the normalized CLTK features

--- a/src/cltk/dependency/stanza.py
+++ b/src/cltk/dependency/stanza.py
@@ -239,7 +239,7 @@ class StanzaWrapper:
         models_dir = os.path.expanduser(
             "~/stanza_resources/"
         )  # TODO: Mv this a self. var or maybe even global
-        processors = None  # if ``None``, then use defaults; was ``"tokenize,mwt,pos,lemma,depparse"``        
+        processors = None  # if ``None``, then use defaults; was ``"tokenize,mwt,pos,lemma,depparse"``
         lemma_use_identity = False
 
         if self.language == "fro":

--- a/src/cltk/dependency/stanza.py
+++ b/src/cltk/dependency/stanza.py
@@ -239,10 +239,11 @@ class StanzaWrapper:
         models_dir = os.path.expanduser(
             "~/stanza_resources/"
         )  # TODO: Mv this a self. var or maybe even global
-        processors = None  # if ``None``, then use defaults; was ``"tokenize,mwt,pos,lemma,depparse"``
+        processors = None  # if ``None``, then use defaults; was ``"tokenize,mwt,pos,lemma,depparse"``        
         lemma_use_identity = False
+
         if self.language == "fro":
-            processors = "tokenize,pos,lemma"
+            processors = "tokenize,pos,lemma,depparse"
             lemma_use_identity = True
 
         nlp = stanza.Pipeline(

--- a/src/cltk/dependency/tree.py
+++ b/src/cltk/dependency/tree.py
@@ -263,12 +263,14 @@ class DependencyTree(ElementTree):
         for word in sentence:
             forms[word.index_token] = Form.to_form(word)
 
+        root = None
         for word in sentence:
             if word.dependency_relation == "root":
                 root = forms[word.index_token]
-            else:
+            elif word.governor != -1:
+                # only add a non-root element to the tree if it has a governor (i.e. not -1)
                 gov = forms[word.governor]
                 dep = forms[word.index_token]
                 gov >> dep | word.dependency_relation
 
-        return DependencyTree(root)
+        return DependencyTree(root) if root else None

--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -1,6 +1,6 @@
 """A module for representing universal morphosyntactic feature bundles."""
 
-from typing import Dict, List, Tuple, Type, Optional, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 from cltk.core.exceptions import CLTKException
 from cltk.morphology.universal_dependencies_features import *

--- a/src/cltk/phonology/grc/transcription.py
+++ b/src/cltk/phonology/grc/transcription.py
@@ -152,12 +152,12 @@ IPA = {
         "y",
         "yː",
         "ɔː",
-        "ɑj", # diphthongs
+        "ɑj",  # diphthongs
         "ɛːj",
-        'ɛːj',
+        "ɛːj",
         "oj",
         "ɔːj",
-        'ɔːj',
+        "ɔːj",
         "yj",
         "ɑw",
         "ew",


### PR DESCRIPTION
Fixes the `fro` stanza pipeline to have depparses in it, so that we now get those in the CLTK `Words`.
The solution doesn't feel right to me, since we should be able to simply pass in the default `processors` argument to the Stanza constructor -- which works when using Stanza directly -- but so far this is the only way it's worked for me.

Also patches `DependencyTree` to make sure it doesn't crash when presented a sentence without dependencies.