### PR TITLE
use class instance as re_non_word_chars is now a property

### DIFF
--- a/src/cltk/sentence/lat.py
+++ b/src/cltk/sentence/lat.py
@@ -23,7 +23,7 @@ from cltk.utils.file_operations import open_pickle
 
 
 class LatinLanguageVars(PunktLanguageVars):
-    _re_non_word_chars = PunktLanguageVars._re_non_word_chars.replace("'", "")
+    _re_non_word_chars = PunktLanguageVars()._re_non_word_chars.replace("'", "")
 
 
 PUNCTUATION = (".", "?", "!")

--- a/src/cltk/tokenizers/lat/lat.py
+++ b/src/cltk/tokenizers/lat/lat.py
@@ -18,7 +18,7 @@ from cltk.tokenizers.word import WordTokenizer
 
 
 class LatinLanguageVars(PunktLanguageVars):
-    _re_non_word_chars = PunktLanguageVars._re_non_word_chars.replace("'", "")
+    _re_non_word_chars = PunktLanguageVars()._re_non_word_chars.replace("'", "")
 
 
 class LatinWordTokenizer(WordTokenizer):


### PR DESCRIPTION
Fixes https://github.com/cltk/cltk/issues/1090.

I'm not familiar with cltk; apologies if either 1. this isn't in style or 2. something else needs this to be a class.  I'll edit if so.