### PR TITLE
Fix BackoffLemmatizer

### DIFF
--- a/src/cltk/lemmatize/backoff.py
+++ b/src/cltk/lemmatize/backoff.py
@@ -101,7 +101,7 @@ class SequentialBackoffLemmatizer(SequentialBackoffTagger):
         lemma = None
         for tagger in self._taggers:
             lemma = tagger.choose_tag(tokens, index, history)
-            if lemma is not None:
+            if lemma is not None and lemma != "":
                 break
         return lemma, tagger
 

--- a/src/cltk/lemmatize/grc.py
+++ b/src/cltk/lemmatize/grc.py
@@ -26,6 +26,8 @@ models_path = os.path.normpath(
 class GreekBackoffLemmatizer:
     """Suggested backoff chain; includes at least on of each
     type of major sequential backoff class from backoff.py
+
+
     """
 
     def __init__(
@@ -105,6 +107,10 @@ class GreekBackoffLemmatizer:
         Lemmatize a list of words.
 
         >>> lemmatizer = GreekBackoffLemmatizer()
+        >>> from cltk.alphabet.text_normalization import cltk_normalize
+        >>> word = cltk_normalize('διοτρεφές')
+        >>> lemmatizer.lemmatize([word])
+        [('διοτρεφές', 'διοτρεφής')]
         >>> lemmatizer.lemmatize("κατέβην χθὲς εἰς Πειραιᾶ μετὰ Γλαύκωνος τοῦ Ἀρίστωνος".split())
         [('κατέβην', 'καταβαίνω'), ('χθὲς', 'χθὲς'), ('εἰς', 'εἰς'), ('Πειραιᾶ', 'Πειραιεύς'), \
 ('μετὰ', 'μετά'), ('Γλαύκωνος', 'Γλαύκων'), ('τοῦ', 'ὁ'), ('Ἀρίστωνος', 'Ἀρίστων')]


### PR DESCRIPTION
Fix BackoffLemmatizer, treat empty strings as None.
Added doctest based on Issue 1051.

Treating empty strings as None seems reasonable; however a deeper review of the mappings is probably warranted.