### PR TITLE
Fixes #1051 issue about train/test split

### DIFF
--- a/src/cltk/lemmatize/grc.py
+++ b/src/cltk/lemmatize/grc.py
@@ -55,13 +55,13 @@ class GreekBackoffLemmatizer:
 
         def _randomize_data(train: List[list], seed: int):
             import random
-
             random.seed(seed)
             random.shuffle(train)
-            pos_train_sents = train[:4000]
+            train_size = int(.9 * len(train))
+            pos_train_sents = train[:train_size]
             lem_train_sents = [[(item[0], item[1]) for item in sent] for sent in train]
-            train_sents = lem_train_sents[:4000]
-            test_sents = lem_train_sents[4000:5000]
+            train_sents = lem_train_sents[:train_size]
+            test_sents = lem_train_sents[train_size:]
 
             return pos_train_sents, train_sents, test_sents
 

--- a/src/cltk/lemmatize/lat.py
+++ b/src/cltk/lemmatize/lat.py
@@ -541,13 +541,13 @@ class LatinBackoffLemmatizer:
 
         def _randomize_data(train: List[list], seed: int):
             import random
-
             random.seed(seed)
             random.shuffle(train)
-            pos_train_sents = train[:4000]
+            train_size = int(.9 * len(train))
+            pos_train_sents = train[:train_size]
             lem_train_sents = [[(item[0], item[1]) for item in sent] for sent in train]
-            train_sents = lem_train_sents[:4000]
-            test_sents = lem_train_sents[4000:5000]
+            train_sents = lem_train_sents[:train_size]
+            test_sents = lem_train_sents[train_size:]
 
             return pos_train_sents, train_sents, test_sents
 


### PR DESCRIPTION
Fixes #1051 issue about train/test split by replacing fixed slices applied to training sentences with a slice based on a 90%/10% split.

i.e.

```
train_size = int(.9 * len(train))
pos_train_sents = train[:train_size]
```

instead of

```
pos_train_sents = train[:4000]
```

Ensures all sentences are used, responds to changes in the underlying training data (i.e. if sentences were ever added, etc.) Applied to both the `lat` and `grc` backoff lemmatizers. 