### PR TITLE
add num form Reference for lat ittb compliance

### DIFF
--- a/src/cltk/morphology/morphosyntax.py
+++ b/src/cltk/morphology/morphosyntax.py
@@ -295,6 +295,7 @@ from_ud_map: Dict[str, Dict[str, MorphosyntacticFeature]] = {
         "Word": NumForm.word,
         "Digit": NumForm.digit,
         "Roman": NumForm.roman,
+        "Reference": NumForm.reference,
     },
     "Case": {
         # structural cases

--- a/src/cltk/morphology/universal_dependencies_features.py
+++ b/src/cltk/morphology/universal_dependencies_features.py
@@ -345,6 +345,7 @@ class NumForm(MorphosyntacticFeature):
     word = auto()
     digit = auto()
     roman = auto()
+    reference = auto()
 
 
 class Definiteness(MorphosyntacticFeature):


### PR DESCRIPTION
fixes: https://github.com/cltk/cltk/issues/1099

Proof:
```
% make shell                                                       
# TODO: start w/ option ``doctest_mode``
poetry run ipython --automagic
Python 3.8.3 (default, Jun 18 2020, 21:39:14) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cltk import NLP

In [2]: nlp=NLP(language='lat')
‎𐤀 CLTK version '1.0.11'.
Pipeline for language 'Latin' (ISO: 'lat'): `LatinNormalizeProcess`, `LatinStanzaProcess`, `LatinEmbeddingsProcess`, `StopsProcess`, `LatinNERProcess`, `LatinLexiconProcess`.

In [3]: doc = nlp("et hoc est quod dicitur ii petri 3-7:")

In [4]: quit()
```