### PR TITLE
add SIF Sentence embeddings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,9 +39,7 @@ copyright = f" 2014-{curr_year} Kyle P. Johnson"
 # author_list: List[str] = cltk_project["authors"]
 # author = ", ".join(author_list)
 # The full version, including alpha/beta/rc tags
-curr_version: pkg_resources.EggInfoDistribution = pkg_resources.get_distribution(
-    "cltk"
-)
+curr_version: pkg_resources.EggInfoDistribution = pkg_resources.get_distribution("cltk")
 release: str = curr_version.version
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -832,6 +832,26 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
+name = "scikit-learn"
+version = "0.24.2"
+description = "A set of python modules for machine learning and data mining"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+joblib = ">=0.11"
+numpy = ">=1.13.3"
+scipy = ">=0.19.1"
+threadpoolctl = ">=2.0.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=2.1.1)", "pandas (>=0.25.0)", "memory-profiler (>=0.57.0)"]
+docs = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)", "memory-profiler (>=0.57.0)", "sphinx (>=3.2.0)", "sphinx-gallery (>=0.7.0)", "numpydoc (>=1.0.0)", "Pillow (>=7.1.2)", "sphinx-prompt (>=1.3.0)"]
+examples = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)"]
+tests = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "mypy (>=0.770)", "pyamg (>=4.0.0)"]
+
+[[package]]
 name = "scipy"
 version = "1.5.4"
 description = "SciPy: Scientific Library for Python"
@@ -1106,6 +1126,14 @@ cuda91 = ["cupy-cuda91 (>=5.0.0b4)"]
 cuda92 = ["cupy-cuda92 (>=5.0.0b4)"]
 
 [[package]]
+name = "threadpoolctl"
+version = "2.1.0"
+description = "threadpoolctl"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -1272,7 +1300,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "425fd1c8e575754fc5eaf3bc3fc3f5be3d2a442c342e699eecb293a199d9dfa8"
+content-hash = "709ecf99b1f9d98711dca73e586637f081caa07e60c49b996bdd099b99e0d1e0"
 
 [metadata.files]
 alabaster = [
@@ -1855,18 +1883,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -1921,6 +1957,41 @@ requests = [
 rtd-poetry = [
     {file = "rtd-poetry-0.1.0.tar.gz", hash = "sha256:21f6d5bc8c2347b1d20c358fcba8f6052a637f3687a1a42393a42e75570ee67c"},
     {file = "rtd_poetry-0.1.0-py3-none-any.whl", hash = "sha256:7feb045e2ba49047e9ce413ec1860eab00ab50de50292ba8633dd48da5acbc67"},
+]
+scikit-learn = [
+    {file = "scikit-learn-0.24.2.tar.gz", hash = "sha256:d14701a12417930392cd3898e9646cf5670c190b933625ebe7511b1f7d7b8736"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:d5bf9c863ba4717b3917b5227463ee06860fc43931dc9026747de416c0a10fee"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5beaeb091071625e83f5905192d8aecde65ba2f26f8b6719845bbf586f7a04a1"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:06ffdcaaf81e2a3b1b50c3ac6842cfb13df2d8b737d61f64643ed61da7389cde"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:fec42690a2eb646b384eafb021c425fab48991587edb412d4db77acc358b27ce"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:5ff3e4e4cf7592d36541edec434e09fb8ab9ba6b47608c4ffe30c9038d301897"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:3cbd734e1aefc7c5080e6b6973fe062f97c26a1cdf1a991037ca196ce1c8f427"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-win32.whl", hash = "sha256:f74429a07fedb36a03c159332b914e6de757176064f9fed94b5f79ebac07d913"},
+    {file = "scikit_learn-0.24.2-cp36-cp36m-win_amd64.whl", hash = "sha256:dd968a174aa82f3341a615a033fa6a8169e9320cbb46130686562db132d7f1f0"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:49ec0b1361da328da9bb7f1a162836028e72556356adeb53342f8fae6b450d47"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f18c3ed484eeeaa43a0d45dc2efb4d00fc6542ccdcfa2c45d7b635096a2ae534"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cdf24c1b9bbeb4936456b42ac5bd32c60bb194a344951acb6bfb0cddee5439a4"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d177fe1ff47cc235942d628d41ee5b1c6930d8f009f1a451c39b5411e8d0d4cf"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:f3ec00f023d84526381ad0c0f2cff982852d035c921bbf8ceb994f4886c00c64"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ae19ac105cf7ce8c205a46166992fdec88081d6e783ab6e38ecfbe45729f3c39"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-win32.whl", hash = "sha256:f0ed4483c258fb23150e31b91ea7d25ff8495dba108aea0b0d4206a777705350"},
+    {file = "scikit_learn-0.24.2-cp37-cp37m-win_amd64.whl", hash = "sha256:39b7e3b71bcb1fe46397185d6c1a5db1c441e71c23c91a31e7ad8cc3f7305f9a"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:90a297330f608adeb4d2e9786c6fda395d3150739deb3d42a86d9a4c2d15bc1d"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f1d2108e770907540b5248977e4cff9ffaf0f73d0d13445ee938df06ca7579c6"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1eec963fe9ffc827442c2e9333227c4d49749a44e592f305398c1db5c1563393"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:2db429090b98045d71218a9ba913cc9b3fe78e0ba0b6b647d8748bc6d5a44080"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:62214d2954377fcf3f31ec867dd4e436df80121e7a32947a0b3244f58f45e455"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8fac72b9688176922f9f54fda1ba5f7ffd28cbeb9aad282760186e8ceba9139a"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-win32.whl", hash = "sha256:ae426e3a52842c6b6d77d00f906b6031c8c2cfdfabd6af7511bb4bc9a68d720e"},
+    {file = "scikit_learn-0.24.2-cp38-cp38-win_amd64.whl", hash = "sha256:038f4e9d6ef10e1f3fe82addc3a14735c299866eb10f2c77c090410904828312"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:48f273836e19901ba2beecd919f7b352f09310ce67c762f6e53bc6b81cacf1f0"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a2a47449093dcf70babc930beba2ca0423cb7df2fa5fd76be5260703d67fa574"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:0e71ce9c7cbc20f6f8b860107ce15114da26e8675238b4b82b7e7cd37ca0c087"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2754c85b2287333f9719db7f23fb7e357f436deed512db3417a02bf6f2830aa5"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:7be1b88c23cfac46e06404582215a917017cd2edaa2e4d40abe6aaff5458f24b"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:4e6198675a6f9d333774671bd536668680eea78e2e81c0b19e57224f58d17f37"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-win32.whl", hash = "sha256:cbdb0b3db99dd1d5f69d31b4234367d55475add31df4d84a3bd690ef017b55e2"},
+    {file = "scikit_learn-0.24.2-cp39-cp39-win_amd64.whl", hash = "sha256:40556bea1ef26ef54bc678d00cf138a63069144a0b5f3a436eecd8f3468b903e"},
 ]
 scipy = [
     {file = "scipy-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4f12d13ffbc16e988fa40809cbbd7a8b45bc05ff6ea0ba8e3e41f6f4db3a9e47"},
@@ -2047,6 +2118,10 @@ thinc = [
     {file = "thinc-7.4.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c408ab24b24e6368ce4b6ddebb579118042a22d3f2f2c4e19ca67e3eadc9ed33"},
     {file = "thinc-7.4.5-cp39-cp39-win_amd64.whl", hash = "sha256:fae320de65af70786c1526ffc33b88f2da650d3106f5f9a06b37f0ac3944a44f"},
     {file = "thinc-7.4.5.tar.gz", hash = "sha256:5743fde41706252ec6ce4737c68d3505f7e1cc3d4431174a17149838d594f8cb"},
+]
+threadpoolctl = [
+    {file = "threadpoolctl-2.1.0-py3-none-any.whl", hash = "sha256:38b74ca20ff3bb42caca8b00055111d74159ee95c4370882bbff2b93d24da725"},
+    {file = "threadpoolctl-2.1.0.tar.gz", hash = "sha256:ddc57c96a38beb63db45d6c159b5ab07b6bced12c45a1f07b2b92f272aebfa6b"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cltk"
-version = "1.0.15"
+version = "1.0.14"
 description = "The Classical Language Toolkit"
 license = "MIT"
 authors = ["Kyle P. Johnson <kyle@kyle-p-johnson.com>", "Patrick J. Burns <patrick@diyclassics.org>", "John Stewart <johnstewart@aya.yale.edu>", "Todd Cook <todd.g.cook@gmail.com>", "Clément Besnier <https://github.com/clemsciences>", "William J. B. Mattingly <https://github.com/wjbmattingly>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ nltk = "^3.5"
 stringcase = "^1.2"
 spacy = "^2.3.5"
 PyYAML = "^5.4.1"
+scikit-learn = "^0.24.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cltk"
-version = "1.0.14"
+version = "1.0.15"
 description = "The Classical Language Toolkit"
 license = "MIT"
 authors = ["Kyle P. Johnson <kyle@kyle-p-johnson.com>", "Patrick J. Burns <patrick@diyclassics.org>", "John Stewart <johnstewart@aya.yale.edu>", "Todd Cook <todd.g.cook@gmail.com>", "Clément Besnier <https://github.com/clemsciences>", "William J. B. Mattingly <https://github.com/wjbmattingly>"]

--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -116,11 +116,11 @@ class Sentence:
     index: int = None
     embedding: np.ndarray = field(repr=False, default=None)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int) -> Word:
         """This indexing operation descends into the word list structure."""
         return self.words[item]
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Returns the number of tokens in the sentence"""
         return len(self.words)
 
@@ -197,7 +197,7 @@ class Doc:
     def sentences(self) -> List[Sentence]:
         """Returns a list of Sentences, with each sentence being a container for a
         list of ``Word`` objects."""
-        sents = defaultdict(list)
+        sents: Dict[int, List[Word]] = defaultdict(list)
         for word in self.words:
             sents[word.index_sentence].append(word)
         for key in sents:

--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -189,25 +189,22 @@ class Doc:
     raw: str = None
     normalized_text: str = None
     embeddings_model = None
-    sent_embeddings: Dict[int, np.ndarray] = field(
-        repr=False, default=None
-    )  #: slot for sentences
+    sentence_embeddings: Dict[int, np.ndarray] = field(repr=False, default=None)
 
     @property
     def sentences(self) -> List[Sentence]:
-        """Returns a list of Sentences, with each sentence being a container for a
+        """Returns a list of ``Sentence``s, with each ``Sentence`` being a container for a
         list of ``Word`` objects."""
         sents: Dict[int, List[Word]] = defaultdict(list)
         for word in self.words:
             sents[word.index_sentence].append(word)
         for key in sents:
             sents[key].sort(key=lambda x: x.index_token)
-        if (
-            not self.sent_embeddings
-        ):  # sometimes not available, nor initialized; e.g. stanza
-            self.sent_embeddings = {}
+        # Sometimes not available, nor initialized; e.g. stanza
+        if not self.sentence_embeddings:
+            self.sentence_embeddings = dict()
         return [
-            Sentence(words=val, index=key, embedding=self.sent_embeddings.get(key))
+            Sentence(words=val, index=key, embedding=self.sentence_embeddings.get(key))
             for key, val in sorted(sents.items(), key=lambda x: x[0])
         ]
 
@@ -216,10 +213,9 @@ class Doc:
         """Returns a list of lists, with the inner list being a
         list of word token strings.
         """
-        sentences_list = self.sentences  # type: List[Sentence]
-        sentences_tokens = list()  # type: List[List[str]]
-        for sentence in sentences_list:
-            sentence_tokens = [word.string for word in sentence]  # type: List[str]
+        sentences_tokens: List[List[str]] = list()
+        for sentence in self.sentences:
+            sentence_tokens: List[str] = [word.string for word in sentence]
             sentences_tokens.append(sentence_tokens)
         return sentences_tokens
 

--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -11,6 +11,7 @@ of the NLP pipeline.
 
 import importlib
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, List, Type, Union
 
@@ -106,6 +107,25 @@ category={}, stop=None, named_entity=None, syllables=None, phonetic_transcriptio
 
 
 @dataclass
+class Sentence:
+    """
+    The Data Container for sentences.
+    """
+
+    words: List[Word] = None
+    index: int = None
+    embedding: np.ndarray = field(repr=False, default=None)
+
+    def __getitem__(self, item):
+        """This indexing operation descends into the word list structure."""
+        return self.words[item]
+
+    def __len__(self):
+        """Returns the number of tokens in the sentence"""
+        return len(self.words)
+
+
+@dataclass
 class Doc:
     """The object returned to the user from the ``NLP()`` class.
     Contains overall attributes of submitted texts, plus most
@@ -169,28 +189,34 @@ class Doc:
     raw: str = None
     normalized_text: str = None
     embeddings_model = None
+    sent_embeddings: Dict[int, np.ndarray] = field(
+        repr=False, default=None
+    )  #: slot for sentences
 
     @property
-    def sentences(self) -> List[List[Word]]:
-        """Returns a list of lists, with the inner list being a
-        list of ``Word`` objects.
-        """
-        sentences = {}
+    def sentences(self) -> List[Sentence]:
+        """Returns a list of Sentences, with each sentence being a container for a
+        list of ``Word`` objects."""
+        sents = defaultdict(list)
         for word in self.words:
-            sentence = sentences.get(word.index_sentence, {})
-            sentence[word.index_token] = word
-            sentences[word.index_sentence] = sentence
-
-        sorted_values = lambda dict: [x[1] for x in sorted(dict.items())]
-
-        return [sorted_values(sentence) for sentence in sorted_values(sentences)]
+            sents[word.index_sentence].append(word)
+        for key in sents:
+            sents[key].sort(key=lambda x: x.index_token)
+        if (
+            not self.sent_embeddings
+        ):  # sometimes not available, nor initialized; e.g. stanza
+            self.sent_embeddings = {}
+        return [
+            Sentence(words=val, index=key, embedding=self.sent_embeddings.get(key))
+            for key, val in sorted(sents.items(), key=lambda x: x[0])
+        ]
 
     @property
     def sentences_tokens(self) -> List[List[str]]:
         """Returns a list of lists, with the inner list being a
         list of word token strings.
         """
-        sentences_list = self.sentences  # type: List[List[Word]]
+        sentences_list = self.sentences  # type: List[Sentence]
         sentences_tokens = list()  # type: List[List[str]]
         for sentence in sentences_list:
             sentence_tokens = [word.string for word in sentence]  # type: List[str]
@@ -202,7 +228,7 @@ class Doc:
         """Returns a list of strings, with each string being
         a sentence reconstructed from the word tokens.
         """
-        sentences_list = self.sentences_tokens  # type: List[List[str]]
+        sentences_list = self.sentences_tokens  # type: List[Sentence]
         sentences_str = list()  # type: List[str]
         for sentence_tokens in sentences_list:  # type: List[str]
             if self.language == "akk":

--- a/src/cltk/embeddings/processes.py
+++ b/src/cltk/embeddings/processes.py
@@ -1,14 +1,18 @@
 """This module holds the embeddings ``Process``es."""
-
+import os
+import pickle
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 import numpy as np
 from boltons.cacheutils import cachedproperty
+from sklearn.decomposition import TruncatedSVD
 
-from cltk.core.data_types import Doc, Process
+from cltk.core.data_types import Doc, Process, Sentence
 from cltk.core.exceptions import CLTKException
 from cltk.embeddings.embeddings import FastTextEmbeddings, Word2VecEmbeddings
+from cltk.utils import CLTK_DATA_DIR
 
 
 @dataclass
@@ -30,6 +34,10 @@ class EmbeddingsProcess(Process):
 
     language: str = None
     variant: str = "fasttext"
+    embedding_length: int = None
+    word_idf: Optional[Dict[str, float]] = field(repr=False, default=None)
+    min_idf = None
+    max_idf = None
 
     @cachedproperty
     def algorithm(self):
@@ -45,20 +53,50 @@ class EmbeddingsProcess(Process):
             )
 
     def run(self, input_doc: Doc) -> Doc:
+        """Compute the embeddings."""
         output_doc = deepcopy(input_doc)
-
-        embedding_length = None
         embeddings_obj = self.algorithm
-
         for index, word_obj in enumerate(output_doc.words):
-            if not embedding_length:
-                embedding_length = embeddings_obj.get_embedding_length()
+            if not self.embedding_length:
+                self.embedding_length = embeddings_obj.get_embedding_length()
             word_embedding = embeddings_obj.get_word_vector(word=word_obj.string)
             if not isinstance(word_embedding, np.ndarray):
-                word_embedding = np.zeros([embedding_length])
+                word_embedding = np.zeros([self.embedding_length])
             word_obj.embedding = word_embedding
             output_doc.words[index] = word_obj
 
+        if not self.word_idf:
+            # You can bring your own model
+            if os.environ.get("WORD_IDF_FILE"):
+                with open(os.environ.get("WORD_IDF_FILE"), "rb") as fin:
+                    self.word_idf = pickle.load(fin)
+            elif TFIDF_MAP.get(self.language):
+                model_path = TFIDF_MAP[self.language]
+                if not os.path.isdir(model_path):
+                    msg = f"TFIDF model path '{model_path}' not found. Going to try to download it ..."
+                    logging.warning(msg)
+                    dl_msg = f"This part of the CLTK depends upon models from the CLTK project."
+                    model_url = f"https://github.com/cltk/{self.language}_models_cltk"
+                    download_prompt(
+                        iso_code=self.language, message=dl_msg, model_url=model_url
+                    )
+                else:
+                    with open(f"{model_path}word_idf.pkl", "rb") as fin:
+                        self.word_idf = pickle.load(fin)
+        # These values are needed while generating sentence embeddings
+        if self.word_idf and not self.min_idf:
+            self.min_idf = np.min(np.array(list(self.word_idf.values())))
+            self.max_idf = np.max(np.array(list(self.word_idf.values())))
+        if self.word_idf:
+            output_doc.sent_embeddings = {}  # type: Dict[int, np.ndarray]
+            for index, sent_obj in enumerate(output_doc.sentences):
+                output_doc.sent_embeddings[index] = get_sent_embeddings(
+                    sent_obj,
+                    self.word_idf,
+                    self.min_idf,
+                    self.max_idf,
+                    self.embedding_length,
+                )
         return output_doc
 
 
@@ -125,3 +163,98 @@ class SanskritEmbeddingsProcess(EmbeddingsProcess):
 
     description: str = "Default embeddings for Sanskrit."
     language: str = "san"
+
+
+TFIDF_MAP = {
+    "lat": os.path.join(
+        CLTK_DATA_DIR,
+        "lat/model/lat_models_cltk/tfidf/",
+    ),
+}
+
+
+def rescale_idf(val: float, min_idf: float, max_idf: float) -> float:
+    """
+    rescale idf values
+    """
+    return (val - min_idf) / (max_idf - min_idf)
+
+
+def compute_pc(X: np.ndarray, npc: int = 1) -> np.ndarray:
+    """
+    Compute the principal components. DO NOT MAKE THE DATA ZERO MEAN!
+    :param X: X[i,:] is a data point
+    :param npc: number of principal components to remove
+    :return: component_[i,:] is the i-th pc
+
+    This has been adapted from the SIF paper code: https://openreview.net/pdf?id=SyK00v5xx
+    """
+    svd = TruncatedSVD(n_components=npc, n_iter=7, random_state=0)
+    svd.fit(X)
+    return svd.components_
+
+
+def remove_pc(X: np.ndarray, npc: int = 1):
+    """
+    Remove the projection on the principal components
+    :param X: X[i,:] is a data point
+    :param npc: number of principal components to remove
+    :return: XX[i, :] is the data point after removing its projection
+
+    This has been adapted from the SIF paper code: https://openreview.net/pdf?id=SyK00v5xx
+    """
+    pc = compute_pc(X, npc)
+    if npc == 1:
+        XX = X - X.dot(pc.transpose()) * pc
+    else:
+        XX = X - X.dot(pc.transpose()).dot(pc)
+    return XX
+
+
+def get_sent_embeddings(
+    sent: Sentence,
+    word_idf: Dict[str, float],
+    min_idf: float,
+    max_idf: float,
+    dimensions: int = 300,
+) -> np.ndarray:
+    """
+    Provides the weighted average of a sentence's word vectors
+    with the principle component removed.
+
+    Expectations:
+    Word can only appear once in a sentence, multiple occurrences are collapsed.
+    Must have 2 or more embeddings, otherwise Principle Component cannot be found and removed.
+
+    :param sent: Sentence
+    :param word_idf: a dictionary of tokens and idf values
+    :param min_idf: the min idf score to use for scaling
+    :param max_idf: the max idf score to use for scaling
+    :param dimensions: the number of dimensions of the embedding
+
+    :return ndarray: values of the sentence embedding, or returns an array of zeroes
+    if no sentence embedding could be computed.
+    """
+    embed_map = {
+        tmp.string: (
+            rescale_idf(word_idf.get(tmp.string.lower(), min_idf), min_idf, max_idf),
+            tmp.embedding,
+        )
+        for tmp in sent.words
+        if not np.all((tmp.embedding == 0))  # skip processing empty embeddings
+    }
+    words = embed_map.keys()
+    weights_embedds = embed_map.values()
+    if (
+        len(weights_embedds) < 2
+    ):  # we can't create a sentence embedding for just one word
+        return np.zeros(dimensions)
+    weights, embedds = zip(*weights_embedds)
+    if sum(weights) == 0:
+        return np.zeros(dimensions)
+    embedds = remove_pc(np.array(embedds))
+    scale_factor = 1 / sum(weights)
+    scaled_vals = np.array([tmp * scale_factor for tmp in weights])
+    # apply our weighted terms to the adjusted embeddings
+    weighted_embeds = embedds * scaled_vals[:, None]
+    return np.sum(weighted_embeds, axis=0)

--- a/src/cltk/embeddings/processes.py
+++ b/src/cltk/embeddings/processes.py
@@ -36,8 +36,8 @@ class EmbeddingsProcess(Process):
     variant: str = "fasttext"
     embedding_length: int = None
     word_idf: Optional[Dict[str, float]] = field(repr=False, default=None)
-    min_idf = None
-    max_idf = None
+    min_idf: Optional[np.float64] = None
+    max_idf: Optional[np.float64] = None
 
     @cachedproperty
     def algorithm(self):
@@ -165,7 +165,7 @@ class SanskritEmbeddingsProcess(EmbeddingsProcess):
     language: str = "san"
 
 
-TFIDF_MAP = {
+TFIDF_MAP: Dict[str, str] = {
     "lat": os.path.join(
         CLTK_DATA_DIR,
         "lat/model/lat_models_cltk/tfidf/",
@@ -235,7 +235,7 @@ def get_sent_embeddings(
     :return ndarray: values of the sentence embedding, or returns an array of zeroes
     if no sentence embedding could be computed.
     """
-    embed_map = {
+    embed_map: Dict[str, Tuple[np.float64, np.ndarray]] = {
         tmp.string: (
             rescale_idf(word_idf.get(tmp.string.lower(), min_idf), min_idf, max_idf),
             tmp.embedding,
@@ -243,8 +243,8 @@ def get_sent_embeddings(
         for tmp in sent.words
         if not np.all((tmp.embedding == 0))  # skip processing empty embeddings
     }
-    words = embed_map.keys()
-    weights_embedds = embed_map.values()
+    words: KeysView = embed_map.keys()
+    weights_embedds: ValuesView = embed_map.values()
     if (
         len(weights_embedds) < 2
     ):  # we can't create a sentence embedding for just one word

--- a/src/cltk/lemmatize/grc.py
+++ b/src/cltk/lemmatize/grc.py
@@ -57,9 +57,10 @@ class GreekBackoffLemmatizer:
 
         def _randomize_data(train: List[list], seed: int):
             import random
+
             random.seed(seed)
             random.shuffle(train)
-            train_size = int(.9 * len(train))
+            train_size = int(0.9 * len(train))
             pos_train_sents = train[:train_size]
             lem_train_sents = [[(item[0], item[1]) for item in sent] for sent in train]
             train_sents = lem_train_sents[:train_size]
@@ -111,8 +112,8 @@ class GreekBackoffLemmatizer:
         >>> word = cltk_normalize('διοτρεφές')
         >>> lemmatizer.lemmatize([word])
         [('διοτρεφές', 'διοτρεφής')]
-        >>> lemmatizer.lemmatize("κατέβην χθὲς εἰς Πειραιᾶ μετὰ Γλαύκωνος τοῦ Ἀρίστωνος".split())
-        [('κατέβην', 'καταβαίνω'), ('χθὲς', 'χθὲς'), ('εἰς', 'εἰς'), ('Πειραιᾶ', 'Πειραιεύς'), \
+        >>> lemmatizer.lemmatize("κατέβην εἰς Πειραιᾶ μετὰ Γλαύκωνος τοῦ Ἀρίστωνος".split())
+        [('κατέβην', 'καταβαίνω'), ('εἰς', 'εἰς'), ('Πειραιᾶ', 'Πειραιεύς'), \
 ('μετὰ', 'μετά'), ('Γλαύκωνος', 'Γλαύκων'), ('τοῦ', 'ὁ'), ('Ἀρίστωνος', 'Ἀρίστων')]
         """
 

--- a/src/cltk/lemmatize/grc.py
+++ b/src/cltk/lemmatize/grc.py
@@ -1,5 +1,4 @@
-"""Module for lemmatizing Ancient Greek
-"""
+"""Module for lemmatizing Ancient Greek."""
 
 __author__ = ["Patrick J. Burns <patrick@diyclassics.org>"]
 __license__ = "MIT License. See LICENSE."
@@ -25,9 +24,7 @@ models_path = os.path.normpath(
 
 class GreekBackoffLemmatizer:
     """Suggested backoff chain; includes at least on of each
-    type of major sequential backoff class from backoff.py
-
-
+    type of major sequential backoff class from backoff.py.
     """
 
     def __init__(
@@ -112,9 +109,9 @@ class GreekBackoffLemmatizer:
         >>> word = cltk_normalize('διοτρεφές')
         >>> lemmatizer.lemmatize([word])
         [('διοτρεφές', 'διοτρεφής')]
-        >>> lemmatizer.lemmatize("κατέβην εἰς Πειραιᾶ μετὰ Γλαύκωνος τοῦ Ἀρίστωνος".split())
-        [('κατέβην', 'καταβαίνω'), ('εἰς', 'εἰς'), ('Πειραιᾶ', 'Πειραιεύς'), \
-('μετὰ', 'μετά'), ('Γλαύκωνος', 'Γλαύκων'), ('τοῦ', 'ὁ'), ('Ἀρίστωνος', 'Ἀρίστων')]
+        >>> republic = cltk_normalize("κατέβην χθὲς εἰς Πειραιᾶ μετὰ Γλαύκωνος τοῦ Ἀρίστωνος")
+        >>> lemmatizer.lemmatize(republic.split())
+        [('κατέβην', 'καταβαίνω'), ('χθὲς', 'χθές'), ('εἰς', 'εἰς'), ('Πειραιᾶ', 'Πειραιεύς'), ('μετὰ', 'μετά'), ('Γλαύκωνος', 'Γλαύκων'), ('τοῦ', 'ὁ'), ('Ἀρίστωνος', 'Ἀρίστων')]
         """
 
         lemmas = self.lemmatizer.lemmatize(tokens)

--- a/src/cltk/lemmatize/lat.py
+++ b/src/cltk/lemmatize/lat.py
@@ -541,9 +541,10 @@ class LatinBackoffLemmatizer:
 
         def _randomize_data(train: List[list], seed: int):
             import random
+
             random.seed(seed)
             random.shuffle(train)
-            train_size = int(.9 * len(train))
+            train_size = int(0.9 * len(train))
             pos_train_sents = train[:train_size]
             lem_train_sents = [[(item[0], item[1]) for item in sent] for sent in train]
             train_sents = lem_train_sents[:train_size]

--- a/src/cltk/wordnet/wordnet.py
+++ b/src/cltk/wordnet/wordnet.py
@@ -1650,8 +1650,7 @@ class WordNetCorpusReader(CorpusReader):
     # }
 
     def __init__(self, iso_code, ignore_errors=False):
-        """Construct a new WordNet corpus reader
-        """
+        """Construct a new WordNet corpus reader"""
         super(WordNetCorpusReader, self).__init__(
             encoding=self._ENCODING, root="", fileids=None
         )


### PR DESCRIPTION
* Added SIF sentence embeddings, implementation based on https://openreview.net/pdf?id=SyK00v5xx and POC implementation at: https://github.com/todd-cook/ML-You-Can-Use/blob/master/quality_embeddings/sentence_similarities_seneca.ipynb 
* Added Sentence object to contain the sentence embedding, and did minor refactoring so that it be indexed as a list of a list of words--as before.
* Added bring-your-own word idf file/env name that can be swapped in to compute the embeddings.
* Added TFIDF mapping for cltk model directory for generic, canned tfidf mapping files.
* Added scikit-learn library for the PCA reduction of the embeddings.
* Corrected problematic doctest for Greek lemmatization.
* minor changes from formatting. 

Also depends on: https://github.com/cltk/lat_models_cltk/pull/9

Verified by the related notebooks and cursorily:
```cltk % make shell
Python 3.8.3 (default, Jun 18 2020, 21:39:14) 
IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cltk import NLP
   ...: from scipy.spatial.distance import cosine
   ...: nlp = NLP(language="lat")
   ...: nlp.pipeline.processes.pop(-1)
   ...: nlp.pipeline.processes.pop(-1)
   ...: nlp.pipeline.processes.pop(-1)
   ...: doc = nlp(
   ...:     "Cotidie enim demitur aliqua pars uitae, et tunc quoque, cum crescimus, uita decrescit. Deinde quod naturale est non decrescit mora, dolorem dies longa consumit."
   ...: )
   ...: print(len(doc.sentences))
   ...: print(cosine(doc.sentences[0].embedding, doc.sentences[1].embedding))
   ...: 
‎𐤀 CLTK version '1.0.14'.
Pipeline for language 'Latin' (ISO: 'lat'): `LatinNormalizeProcess`, `LatinStanzaProcess`, `LatinEmbeddingsProcess`, `StopsProcess`, `LatinNERProcess`, `LatinLexiconProcess`.
2
0.3677302800367781
```
