### PR TITLE
Fix doctest and tokenizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cltk"
-version = "1.0.17"
+version = "1.0.18"
 description = "The Classical Language Toolkit"
 license = "MIT"
 authors = ["Kyle P. Johnson <kyle@kyle-p-johnson.com>", "Patrick J. Burns <patrick@diyclassics.org>", "John Stewart <johnstewart@aya.yale.edu>", "Todd Cook <todd.g.cook@gmail.com>", "Clément Besnier <https://github.com/clemsciences>", "William J. B. Mattingly <https://github.com/wjbmattingly>"]

--- a/src/cltk/alphabet/text_normalization.py
+++ b/src/cltk/alphabet/text_normalization.py
@@ -86,7 +86,7 @@ def split_leading_punct(text: str, punctuation: Optional[List[str]] = None) -> s
     Returns:
         Text string with leading punctuation separated by a whitespace character.
 
-    raw_text = "‘κατηγόρων’, οὐκ οἶδα: ἐγὼ δ᾽ οὖν"
+    >>> raw_text = "‘κατηγόρων’, οὐκ οἶδα: ἐγὼ δ᾽ οὖν"
     >>> split_leading_punct(text=raw_text)
     '‘ κατηγόρων’, οὐκ οἶδα: ἐγὼ δ᾽ οὖν'
     """

--- a/src/cltk/sentence/sentence.py
+++ b/src/cltk/sentence/sentence.py
@@ -10,6 +10,7 @@ __license__ = "MIT License. See LICENSE."
 
 import os
 import re
+from abc import ABC, abstractmethod
 from typing import List
 
 from nltk.tokenize.punkt import PunktSentenceTokenizer as NLTKPunktSentenceTokenizer
@@ -18,9 +19,10 @@ from cltk.utils import CLTK_DATA_DIR
 from cltk.utils.file_operations import open_pickle
 
 
-class SentenceTokenizer:
-    """ Base class for sentences tokenization"""
+class SentenceTokenizer(ABC):
+    """Base class for sentences tokenization"""
 
+    @abstractmethod
     def __init__(self, language: str = None):
         """Initialize stoplist builder with option for language specific parameters
         :param language : language for sentences tokenization
@@ -65,11 +67,10 @@ class PunktSentenceTokenizer(SentenceTokenizer):
         :param language : language for sentences tokenization
         :type language: str
         """
-        self.language = language
+        super().__init__(language=language)
         if self.language == "lat":
             self.language_old = "lat"
         self.lang_vars = lang_vars
-        super().__init__(language=self.language)
         if self.language:
             self.models_path = self._get_models_path(self.language)
             try:
@@ -99,7 +100,7 @@ class RegexSentenceTokenizer(SentenceTokenizer):
             self.sent_end_chars_regex = "|".join(self.sent_end_chars)
             self.pattern = rf"(?<=[{self.sent_end_chars_regex}])\s"
         else:
-            raise Exception  # TODO add message, must specify sent_end_chars, or warn and use defaults
+            raise Exception("Must specify sent_end_chars")
 
     def tokenize(self, text: str, model: object = None) -> List[str]:
         """


### PR DESCRIPTION
Fix sentence tokenizer so that it can't be instantiated by itself (since it's a base class), minor corrections on initialization order and error handling.

change motivated by: https://github.com/cltk/cltk/issues/1120

This is the expected behavior:

```
% make shell
# TODO: start w/ option ``doctest_mode``
poetry run ipython --automagic
Python 3.8.3 (default, Jun 18 2020, 21:39:14) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.25.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cltk.sentence.sentence import PunktSentenceTokenizer

In [2]: toker = PunktSentenceTokenizer(language='LAT')

In [3]: toker.tokenize('quid est ueritas. uir qui adest.')
Out[3]: ['quid est ueritas.', 'uir qui adest.']

In [4]: from cltk.sentence.sentence import SentenceTokenizer

In [5]: sent_toker = SentenceTokenizer('lat')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-2dce4df240a1> in <module>
----> 1 sent_toker = SentenceTokenizer('lat')

TypeError: Can't instantiate abstract class SentenceTokenizer with abstract methods __init__
```
