### PR TITLE
Fix normalization process as described in #1143; add test

### DIFF
--- a/src/cltk/alphabet/grc/grc.py
+++ b/src/cltk/alphabet/grc/grc.py
@@ -644,9 +644,7 @@ def tonos_oxia_converter(text, reverse=False):
 
 def normalize_grc(text: str) -> str:
     """The function for all default Greek normalization."""
-    # text_cltk_normalized: str = cltk_normalize(text=text)
-    text_oxia_converted: str = tonos_oxia_converter(text=text)
-    # text_punct_processed: str = split_trailing_punct(text=text_oxia_converted)
-    # text_punct_processed = split_leading_punct(text=text_punct_processed)
-    text_punct_processed: str = remove_odd_punct(text=text_oxia_converted)
+    text_oxia_converted = tonos_oxia_converter(text=text)  # type: str
+    text_oxia_converted_norm = cltk_normalize(text=text_oxia_converted)
+    text_punct_processed = remove_odd_punct(text=text_oxia_converted_norm)
     return text_punct_processed

--- a/tests/test_alphabet.py
+++ b/tests/test_alphabet.py
@@ -1,0 +1,23 @@
+"""Test ``cltk.alphabet``."""
+
+__license__ = "MIT License. See LICENSE."
+
+import unittest
+import unicodedata
+
+from cltk.alphabet.grc.grc import normalize_grc
+
+
+class TestSequenceFunctions(unittest.TestCase):  # pylint: disable=R0904
+    """Class for unittest"""
+
+    def test_normalize_grc(self):
+        """Test for normalizing grc input"""
+        source = "Ἡροδότου Ἁλικαρνησσέος ἱστορίης ἀπόδεξις ἥδε"
+        source_nfd = unicodedata.normalize("NFD", source)
+        target = normalize_grc(source_nfd)
+        self.assertEqual(source, target)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Switched order of `tonos_oxia_converter` and `cltk_normalize` in `normalize_grc` to address problems with the normalization process described in #1143 
- Added test