### PR TITLE
make Latin enclitic tokenizer work

### DIFF
--- a/src/cltk/tokenizers/lat/lat.py
+++ b/src/cltk/tokenizers/lat/lat.py
@@ -136,6 +136,8 @@ class LatinWordTokenizer(WordTokenizer):
                     if token.endswith(enclitic):
                         if enclitic == "n":
                             specific_tokens += [token[: -len(enclitic)]] + ["-ne"]
+                        elif token == "-ne" and enclitic == "ne":
+                            specific_tokens += [token]
                         elif enclitic == "st":
                             if token.endswith("ust"):
                                 specific_tokens += [token[: -len(enclitic) + 1]] + [
@@ -144,7 +146,9 @@ class LatinWordTokenizer(WordTokenizer):
                             else:
                                 specific_tokens += [token[: -len(enclitic)]] + ["est"]
                         else:
-                            specific_tokens += [token]
+                            specific_tokens += [token[: -len(enclitic)]] + [
+                                "-" + enclitic
+                            ]
                         is_enclitic = True
                         break
             if not is_enclitic:


### PR DESCRIPTION
As reported in #1190, the LatinWordTokenizer does not work since https://github.com/cltk/cltk/commit/137e1925fbf29a8338a43f81ec8bdd4bf478e917. Maybe someone who understands what [lines 117-120](https://github.com/andbue/cltk/blob/429283e1a46ff11fc8a13f57f74d7eccad5e7391/src/cltk/tokenizers/lat/lat.py#L117C1-L120C61) are supposed to do should check if this breaks anything else.