### PR TITLE
Scansion adjustment, issue #1246

### DIFF
--- a/src/cltk/prosody/grc.py
+++ b/src/cltk/prosody/grc.py
@@ -263,7 +263,7 @@ class Scansion:
                 vowel_group += char
         return bool("".join(vowel_group) in self.diphthongs)
 
-    def _long_by_position(self, syllable: str, sentence: list[str]) -> bool:
+    def _long_by_position(self, sentence_index, syllable: str, sentence: list[str]) -> bool:
         """Check if syllable is long by position. Returns ``True``
         if syllable is long by position Long by position
         includes contexts when:
@@ -285,10 +285,10 @@ class Scansion:
         [True, False, False, False, False]
         """
         try:
-            next_syll = sentence[sentence.index(syllable) + 1]
+            next_syll = sentence[sentence_index + 1]
             # Long by position by case 1
             if (next_syll[0] in self.sing_cons and next_syll[1] in self.sing_cons) and (
-                next_syll[0] not in self.stops and next_syll[1] not in self.liquids
+                next_syll[0] not in self.stops or next_syll[1] not in self.liquids
             ):
                 return True
             # Long by position by case 2
@@ -321,8 +321,8 @@ class Scansion:
         scanned_text = list()
         for sentence in sentence_syllables:
             scanned_sent = list()
-            for syllable in sentence:
-                if self._long_by_position(syllable, sentence) or self._long_by_nature(
+            for i, syllable in enumerate(sentence):   
+                if self._long_by_position(i, syllable, sentence) or self._long_by_nature(
                     syllable
                 ):
                     scanned_sent.append("¯")


### PR DESCRIPTION
Minor changes to the Scansion Module for Ancient Greek.

290-91 to
```
if (next_syll[0] in self.sing_cons and next_syll[1] in self.sing_cons) and (
next_syll[0] not in self.stops or next_syll[1] not in self.liquids)
```
to fix problems with mute/liquid detection


And also to fix the problem with repeated syllables in the same sentence

line 266 to:` def _long_by_position(self, sentence_index, syllable: str, sentence: list[str]) -> bool:`

288 to: `next_syll = sentence[sentence_index + 1]`
using the variable sentence_index to locate the syllable in question as a part of the function _long_by_position. The variable is set in the _scansion function.

324 to: `for i, syllable in enumerate(sentence):`
325 to: `if self._long_by_position(i, syllable, sentence) or self._long_by_nature(
`
These fairly minimal changes (with the change to the logic of lines 290–291) make the line ἀνδρῶν ἀρίστων, οἳ τὸ πάγχρυσον δέρας scan ['¯¯˘¯¯¯˘¯˘¯˘x'], and have removed repeated syllable errors in other texts I have tried.
Combi Check old above, new middle top.

Compare the opening to Demosthenes De Corona in the old version, the new version, my scansion, and then the (admittedly controversial, there are some lengths that are non standard for a modern scholar) scansion from Dionysius of Halicarnassus (from Usher's loeb analysis, pg 141, with some small adjustments to bring the texts in line). The remaining discrepancies probably need a dedicated dictionary for minor words.

old:  '¯¯˘¯¯˘¯¯¯¯¯˘¯¯˘¯¯˘¯˘¯˘¯¯¯˘˘¯˘¯˘¯˘¯¯˘˘¯¯¯˘˘¯˘¯¯˘˘¯¯˘˘¯¯¯˘˘¯¯¯x.
new:'¯¯˘¯¯˘˘¯¯¯¯˘¯¯˘¯¯˘¯˘¯˘¯¯¯˘˘¯˘¯˘˘˘¯¯˘˘¯¯¯˘˘¯˘¯¯˘¯¯¯˘˘¯¯¯˘˘˘˘¯x.
my:  ‘¯¯˘¯¯˘˘¯¯¯¯˘¯¯˘¯¯˘¯˘¯˘¯¯¯˘˘¯˘¯˘˘˘¯¯˘˘¯¯¯˘¯¯˘¯¯˘¯¯¯˘¯¯¯¯˘˘˘˘¯x
Dio:  ‘¯¯˘¯¯˘˘¯¯¯¯˘¯¯˘¯¯˘¯¯¯˘¯¯¯⏓⏑¯˘¯˘˘˘¯¯˘˘˘¯¯⏒¯¯˘¯¯˘¯¯¯˘¯¯¯¯⏒⏒˘¯x.

πρῶ | τον|μέν| ὦ |ἄν |δρες| Ἀθ|ην|αῖ|  οι| τοῖς | θε|οῖς | εὔχ|ο |  μαι| πᾶσ|ι | καὶ |πάσ|αις|ὅσ|ην|εὔν| οι| αν| ἔχ|  ων| ἐ|   γὼ |δι | ατ | ε| λῶ| τῇ|   τε | πόλ|ει| καὶ|πᾶσ|ιν|  ὑμ| ῖν, |τοσ|αύ|την |ὑπ|άρξ|αι |μοι|παρ|ὑμ|ῶν| εἰς| του|το|νὶ | τὸν |ἀγ| ῶν| α.

CLTK syllables πρω', 'τον'], ['μεν'], ['ω'], ['α', 'νδρες'], ['α', 'θη', 'ναῖ', 'οι'], ['τοῖς'], ['θε', 'οῖς'], ['ευ', 'χο', 'μαι'], ['πᾶ', 'σι'], ['και'], ['πα', 'σαις'], ['ο', 'σην'], ['ευ', 'νοι', 'αν'], ['ε', 'χων'], ['ε', 'γω'], ['δι', 'α', 'τε', 'λω'], ['τη'], ['τε'], ['πο', 'λει'], ['και'], ['πᾶ', 'σιν'], ['υ', 'μῖν'], ['το', 'σαυ', 'την'], ['υ', 'πα', 'ρξαι'], ['μοι'], ['παρ'], ['υ', 'μων'], ['εις'], ['του', 'το', 'νι'], ['τον'], ['α', 'γω', 'να'].
