### PR TITLE
Correct translation notes for non-English translations

### DIFF
--- a/docs/translation.md
+++ b/docs/translation.md
@@ -92,7 +92,7 @@ The above outputs:
 
 ```
 Translation: Toute la Gaule est divisée en trois parties.
-Notes: «omnis» rendered as «toute» to convey ‘all/whole’; «divisa» is a perfect passive participle agreeing with «Gallia», hence passive French «est divisée». Word order follows natural French syntax.
+Notes: J'ai rendu 'Gallia omnis' par «Toute la Gaule» (on pourrait aussi dire «La Gaule tout entière»). Le participe passif 'divisa ... est' devient «est divisée» et 'partes tres' = «trois parties».
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cltk"
-version = "2.3.5"
+version = "2.3.6"
 description = "The Classical Language Toolkit"
 authors = [
     {name = "Kyle P. Johnson", email = "kyle@kyle-p-johnson.com"},

--- a/src/cltk/genai/prompts.py
+++ b/src/cltk/genai/prompts.py
@@ -141,14 +141,14 @@ def translation_prompt(
 ) -> PromptInfo:
     """Build a translation prompt that leverages prior annotations."""
     kind: str = "translation"
-    version: str = "1.0"
+    version: str = "1.1"
     text: str = (
         f"Translate the following {lang_or_dialect_name} sentence into {target_language}. "
         "Use the provided morphosyntax, dependency relations, glosses, lemma translations, idiom hints, and pedagogy notes instead of translating from scratch. "
         "Rely on those annotations as much as possible; adjust only when a gloss or valence appears inaccurate.\n\n"
         "Return a JSON object inside a markdown code block with:\n"
         "- `translation`: the final fluent translation.\n"
-        "- `notes`: 1-3 sentences highlighting difficult or non-obvious decisions (e.g., idioms, ambiguous morphology, pragmatic nuance).\n\n"
+        f"- `notes`: 1-3 sentences (in {target_language}) highlighting difficult or non-obvious decisions (e.g., idioms, ambiguous morphology, pragmatic nuance).\n\n"
         f"Context:\n\n{context}\n"
     )
     return PromptInfo(


### PR DESCRIPTION
Ensure that the model's translation notes are in the same language as the text's target language.