### PR TITLE
Loosen BACKEND_TYPES to accept plain str (fixes #1322)

### DIFF
--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -39,8 +39,8 @@ ISOType: TypeAlias = Literal["639-1", "639-2", "639-3"]
 ScriptDir: TypeAlias = Literal["ltr", "rtl", "ttb", "btt"]
 
 
-BACKEND_TYPES: TypeAlias = Literal[
-    "openai", "stanza", "spacy", "ollama", "ollama-cloud", "mistral"
+BACKEND_TYPES: TypeAlias = Union[
+    Literal["openai", "stanza", "spacy", "ollama", "ollama-cloud", "mistral"], str
 ]
 AVAILABLE_OPENAI_MODELS: TypeAlias = Literal["gpt-5-mini", "gpt-5"]
 


### PR DESCRIPTION
Loosens `BACKEND_TYPES` to `Union[Literal[...], str]` so plain string variables are accepted without a type-checker error, per the issue. Keeps the existing Literal values for autocomplete/documentation purposes.

Fixes #1322