### PR TITLE
feat: add LiteLLM backend

### DIFF
--- a/LLM_DEV_GUIDE.md
+++ b/LLM_DEV_GUIDE.md
@@ -14,8 +14,8 @@ This guide tells humans and LLM-based helpers how to extend or modify CLTK's Gen
 - Responses are normalized to `CLTKGenAIResponse` (`src/cltk/core/data_types.py`); keep that shape stable.
 
 ## Runtime, configuration, dependencies
-- Supported extras: `cltk[openai]` and `cltk[ollama]`. Env vars: `OPENAI_API_KEY`, `OLLAMA_CLOUD_API_KEY`. Use `.env` loading via `load_env_file()` when needed.
-- Default models: OpenAI backend uses `gpt-5-mini` by default; Ollama backend uses `llama3.1:8b`. Override via the `model` parameter; document any non-default you hardcode.
+- Supported extras: `cltk[openai]` and `cltk[ollama]`. Env vars: `OPENAI_API_KEY`, `LITELLM_API_KEY`, `LITELLM_BASE_URL`, `OLLAMA_CLOUD_API_KEY`. Use `.env` loading via `load_env_file()` when needed.
+- Default models: OpenAI backend uses `gpt-5-mini` by default; Ollama backend uses `llama3.1:8b`. LiteLLM requires a proxy model alias through `model` or `LITELLM_MODEL`. Override via the `model` parameter; document any non-default you hardcode.
 - Keep temperature, top_p, and timeouts explicit; set conservative defaults (e.g., low temperature) for reproducibility.
 - Do not add new network calls outside the existing clients; prefer dependency-free utilities from `src/cltk/utils/` and `src/cltk/text/`.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ nlp_big = NLP('lati1261', backend='openai', model='gpt-5')
 # (e.g., via a .env file or shell env var)
 ```
 
+- LiteLLM proxy (any model configured behind the gateway):
+
+Install the OpenAI client extra with `pip install "cltk[openai]"`, then:
+
+```python
+from cltk import NLP
+
+# Set LITELLM_API_KEY and optionally LITELLM_BASE_URL
+nlp_proxy = NLP('lati1261', backend='litellm', model='your-proxy-model-alias')
+```
+
 - Ollama backend (local LLMs):
 
 ```python

--- a/docs/advanced-model-configuration.md
+++ b/docs/advanced-model-configuration.md
@@ -35,6 +35,28 @@ cltk_config = CLTKConfig(
 nlp = NLP(cltk_config=cltk_config)
 ```
 
+## LiteLLM: proxy URL and model alias
+
+This backend uses the OpenAI client extra (`pip install "cltk[openai]"`). If
+`base_url` is omitted, CLTK reads `LITELLM_BASE_URL` and otherwise defaults to
+`http://localhost:4000/v1`.
+
+```python
+from cltk.core.data_types import CLTKConfig, LiteLLMBackendConfig
+
+cltk_config = CLTKConfig(
+    language_code="lati1261",
+    backend="litellm",
+    litellm=LiteLLMBackendConfig(
+        model="your-proxy-model-alias",
+        base_url="https://litellm.example.com/v1",
+        temperature=0.4,
+        # api_key="sk-...",  # overrides LITELLM_API_KEY if provided
+    ),
+)
+nlp = NLP(cltk_config=cltk_config)
+```
+
 ## OpenAI / ChatGPT: temperature and retries
 
 ```python
@@ -119,9 +141,10 @@ nlp = NLP(cltk_config=cltk_config)
 
 - Only one backend config block should be provided at a time; Pydantic validation will raise if more than one is set.
 - When `cltk_config` is supplied, its values override the individual `NLP()` arguments (`language_code`, `backend`, `model`, `custom_pipeline`, `suppress_banner`).
-- API keys in the config blocks take precedence over environment variables like `OPENAI_API_KEY`, `MISTRAL_API_KEY`, and `OLLAMA_CLOUD_API_KEY`.
+- API keys in the config blocks take precedence over environment variables like `OPENAI_API_KEY`, `LITELLM_API_KEY`, `MISTRAL_API_KEY`, and `OLLAMA_CLOUD_API_KEY`.
 - Currently applied knobs per backend:
   - Stanza: `stanza.model` selects the UD package/treebank (`package` in Stanza).
   - OpenAI: `temperature`, `api_key`, `max_retries`.
+  - LiteLLM: `model`, `base_url`, `temperature`, `api_key`, `max_retries`.
   - Mistral: `temperature`, `api_key`, `max_retries`.
   - Ollama: `temperature`, `top_p`, `num_ctx`, `num_predict`, `options`, `host`/`port`, `api_key`, `max_retries`.

--- a/src/cltk/core/data_types.py
+++ b/src/cltk/core/data_types.py
@@ -40,7 +40,10 @@ ScriptDir: TypeAlias = Literal["ltr", "rtl", "ttb", "btt"]
 
 
 BACKEND_TYPES: TypeAlias = Union[
-    Literal["openai", "stanza", "spacy", "ollama", "ollama-cloud", "mistral"], str
+    Literal[
+        "openai", "litellm", "stanza", "spacy", "ollama", "ollama-cloud", "mistral"
+    ],
+    str,
 ]
 AVAILABLE_OPENAI_MODELS: TypeAlias = Literal["gpt-5-mini", "gpt-5"]
 
@@ -568,6 +571,16 @@ class OpenAIBackendConfig(ModelConfig):
     api_key: Optional[str] = None
 
 
+class LiteLLMBackendConfig(ModelConfig):
+    """Options for an OpenAI-compatible LiteLLM proxy."""
+
+    model: Optional[str] = None
+    temperature: float = Field(default=1.0, ge=0, le=2)
+    max_retries: int = Field(default=2, ge=0)
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+
+
 class MistralBackendConfig(ModelConfig):
     """Options specific to the Mistral backend."""
 
@@ -627,6 +640,7 @@ class CLTKConfig(BaseModel):
 
     stanza: Optional[StanzaBackendConfig] = None
     openai: Optional[OpenAIBackendConfig] = None
+    litellm: Optional[LiteLLMBackendConfig] = None
     mistral: Optional[MistralBackendConfig] = None
     ollama: Optional[OllamaBackendConfig] = None
 
@@ -640,6 +654,7 @@ class CLTKConfig(BaseModel):
         mapping: dict[str, Optional[ModelConfig]] = {
             "stanza": self.stanza,
             "openai": self.openai,
+            "litellm": self.litellm,
             "mistral": self.mistral,
             "ollama": self.ollama,
             "ollama-cloud": self.ollama,
@@ -663,6 +678,7 @@ class CLTKConfig(BaseModel):
             for name, cfg in (
                 ("stanza", self.stanza),
                 ("openai", self.openai),
+                ("litellm", self.litellm),
                 ("mistral", self.mistral),
                 ("ollama", self.ollama),
             )
@@ -676,6 +692,7 @@ class CLTKConfig(BaseModel):
             allowed_for_backend: dict[str, set[str]] = {
                 "stanza": {"stanza"},
                 "openai": {"openai"},
+                "litellm": {"litellm"},
                 "mistral": {"mistral"},
                 "ollama": {"ollama"},
                 "ollama-cloud": {"ollama"},

--- a/src/cltk/dependency/utils.py
+++ b/src/cltk/dependency/utils.py
@@ -13,6 +13,7 @@ from cltk.core.data_types import (
     AVAILABLE_OPENAI_MODELS,
     CLTKGenAIResponse,
     Doc,
+    LiteLLMBackendConfig,
     MistralBackendConfig,
     ModelConfig,
     OllamaBackendConfig,
@@ -29,7 +30,12 @@ from cltk.core.provenance import (
 )
 from cltk.genai.mistral import AsyncMistralConnection, MistralConnection
 from cltk.genai.ollama import AsyncOllamaConnection, OllamaConnection
-from cltk.genai.openai import AsyncOpenAIConnection, OpenAIConnection
+from cltk.genai.openai import (
+    AsyncLiteLLMConnection,
+    AsyncOpenAIConnection,
+    LiteLLMConnection,
+    OpenAIConnection,
+)
 from cltk.genai.prompts import PromptInfo, _hash_prompt
 from cltk.morphosyntax.ud_deprels import UDDeprelTag, get_ud_deprel_tag
 from cltk.morphosyntax.utils import _update_doc_genai_stage
@@ -303,6 +309,19 @@ def generate_dependency_tree(
                 api_key=getattr(openai_cfg, "api_key", None),
                 temperature=getattr(openai_cfg, "temperature", 1.0),
             )
+    elif doc.backend == "litellm":
+        if not client:
+            litellm_cfg = (
+                backend_config
+                if isinstance(backend_config, LiteLLMBackendConfig)
+                else None
+            )
+            client = LiteLLMConnection(
+                model=str(doc.model),
+                api_key=getattr(litellm_cfg, "api_key", None),
+                base_url=getattr(litellm_cfg, "base_url", None),
+                temperature=getattr(litellm_cfg, "temperature", 1.0),
+            )
     elif doc.backend in ("ollama", "ollama-cloud"):
         if not client:
             ollama_cfg = (
@@ -494,6 +513,8 @@ def generate_gpt_dependency(
             )
         openai_model: AVAILABLE_OPENAI_MODELS = cast(AVAILABLE_OPENAI_MODELS, doc.model)
         client = OpenAIConnection(model=openai_model)
+    elif doc.backend == "litellm":
+        client = LiteLLMConnection(model=str(doc.model))
     elif doc.backend in ("ollama", "ollama-cloud"):
         client = OllamaConnection(
             model=str(doc.model),
@@ -680,6 +701,16 @@ async def generate_gpt_dependency_async(
             model=openai_model,
             api_key=getattr(openai_cfg, "api_key", None),
             temperature=getattr(openai_cfg, "temperature", 1.0),
+        )
+    elif doc.backend == "litellm":
+        litellm_cfg = (
+            backend_config if isinstance(backend_config, LiteLLMBackendConfig) else None
+        )
+        conn = AsyncLiteLLMConnection(
+            model=str(doc.model),
+            api_key=getattr(litellm_cfg, "api_key", None),
+            base_url=getattr(litellm_cfg, "base_url", None),
+            temperature=getattr(litellm_cfg, "temperature", 1.0),
         )
     elif doc.backend in ("ollama", "ollama-cloud"):
         ollama_cfg = (

--- a/src/cltk/enrichment/utils.py
+++ b/src/cltk/enrichment/utils.py
@@ -16,6 +16,7 @@ from cltk.core.data_types import (
     IdiomSpan,
     IPAEnrichment,
     LemmaTranslationCandidate,
+    LiteLLMBackendConfig,
     MistralBackendConfig,
     ModelConfig,
     OllamaBackendConfig,
@@ -37,7 +38,7 @@ from cltk.core.provenance import (
 )
 from cltk.genai.mistral import MistralConnection
 from cltk.genai.ollama import OllamaConnection
-from cltk.genai.openai import OpenAIConnection
+from cltk.genai.openai import LiteLLMConnection, OpenAIConnection
 from cltk.genai.prompts import PromptInfo, _hash_prompt, enrichment_prompt
 from cltk.morphosyntax.utils import _update_doc_genai_stage
 
@@ -582,6 +583,16 @@ def generate_gpt_enrichment(
             model=cast(AVAILABLE_OPENAI_MODELS, doc.model),
             api_key=getattr(openai_cfg, "api_key", None),
             temperature=getattr(openai_cfg, "temperature", 1.0),
+        )
+    elif doc.backend == "litellm":
+        litellm_cfg = (
+            backend_config if isinstance(backend_config, LiteLLMBackendConfig) else None
+        )
+        client = LiteLLMConnection(
+            model=str(doc.model),
+            api_key=getattr(litellm_cfg, "api_key", None),
+            base_url=getattr(litellm_cfg, "base_url", None),
+            temperature=getattr(litellm_cfg, "temperature", 1.0),
         )
     elif doc.backend in ("ollama", "ollama-cloud"):
         ollama_cfg = (

--- a/src/cltk/genai/openai.py
+++ b/src/cltk/genai/openai.py
@@ -14,6 +14,7 @@ __license__ = "MIT License. See LICENSE."
 
 import os
 import re
+from types import SimpleNamespace
 from typing import Any, Optional, cast
 
 from cltk.core.cltk_logger import bind_context
@@ -62,6 +63,19 @@ def _resolve_openai_classes() -> (
 OpenAI, AsyncOpenAI, OpenAIError = _resolve_openai_classes()
 
 
+def _litellm_output_text(response: Any) -> str:
+    """Extract non-empty text from an OpenAI-compatible chat response."""
+    try:
+        content = response.choices[0].message.content
+    except (AttributeError, IndexError, TypeError) as error:
+        raise CLTKException(
+            "LiteLLM returned an empty or malformed response."
+        ) from error
+    if not isinstance(content, str) or not content.strip():
+        raise CLTKException("LiteLLM returned an empty or malformed response.")
+    return content
+
+
 class OpenAIConnection:
     """Thin wrapper around the OpenAI client for CLTK use cases.
 
@@ -80,6 +94,7 @@ class OpenAIConnection:
         model: AVAILABLE_OPENAI_MODELS,
         api_key: Optional[str] = None,
         temperature: float = 1.0,
+        _base_url: Optional[str] = None,
     ):
         """Initialize the client and resolve language/dialect metadata."""
         self.api_key = api_key
@@ -103,7 +118,11 @@ class OpenAIConnection:
                     "OpenAI client not installed. Install with: pip install 'cltk[openai]'"
                 ) from e
             openai_cls = runtime_openai
-        self.client = openai_cls(api_key=self.api_key)
+        client_kwargs: dict[str, Any] = {"api_key": self.api_key}
+        if _base_url:
+            client_kwargs["base_url"] = _base_url.rstrip("/")
+        self.client = openai_cls(**client_kwargs)
+        self._is_litellm = _base_url is not None
         # Structured logger bound with model identifier
         self.log = bind_context(model=str(self.model))
 
@@ -112,7 +131,9 @@ class OpenAIConnection:
         prompt: str,
         max_retries: int = 2,
     ) -> CLTKGenAIResponse:
-        """Call the OpenAI responses API synchronously with retries and code-block parsing."""
+        """Generate text through OpenAI Responses or LiteLLM Chat Completions."""
+        if max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
         # Avoid logging full prompt contents unless explicitly enabled
         import os as _os
 
@@ -132,7 +153,17 @@ class OpenAIConnection:
             self.log.debug(f"Attempt {attempt} of {max_retries}")
             try:
                 # TODO: Disable 4.1
-                if "4.1" in self.model:
+                if self._is_litellm:
+                    chat_response = self.client.chat.completions.create(
+                        model=self.model,
+                        messages=[{"role": "user", "content": prompt}],
+                        temperature=self.temperature,
+                    )
+                    content = _litellm_output_text(chat_response)
+                    openai_response = SimpleNamespace(
+                        output_text=content, usage=chat_response.usage
+                    )
+                elif "4.1" in self.model:
                     openai_response = self.client.responses.create(
                         model=self.model, input=prompt, temperature=self.temperature
                     )
@@ -185,6 +216,9 @@ class OpenAIConnection:
                     raise CLTKException(final_err)
                     # return doc
                 # Optionally, you could modify the prompt or add a delay here
+
+        if not code_block:
+            raise CLTKException("No code blocks found in response after retries.")
         assert openai_response
         # Use the accumulated usage across all attempts
         openai_usage: dict[str, int] = agg_tokens
@@ -300,6 +334,7 @@ class AsyncOpenAIConnection:
         model: AVAILABLE_OPENAI_MODELS,
         api_key: Optional[str] = None,
         temperature: float = 1.0,
+        _base_url: Optional[str] = None,
     ) -> None:
         self.api_key = api_key
         self.model: str = model
@@ -320,7 +355,11 @@ class AsyncOpenAIConnection:
                     "OpenAI client not installed. Install with: pip install 'cltk[openai]'"
                 ) from e
             async_openai_cls = runtime_async_openai
-        self.client = async_openai_cls(api_key=self.api_key)
+        client_kwargs: dict[str, Any] = {"api_key": self.api_key}
+        if _base_url:
+            client_kwargs["base_url"] = _base_url.rstrip("/")
+        self.client = async_openai_cls(**client_kwargs)
+        self._is_litellm = _base_url is not None
         # Structured logger bound with model identifier
         self.log = bind_context(model=str(self.model))
 
@@ -329,7 +368,9 @@ class AsyncOpenAIConnection:
         prompt: str,
         max_retries: int = 2,
     ) -> CLTKGenAIResponse:
-        """Call the OpenAI responses API asynchronously with retries."""
+        """Generate text asynchronously through OpenAI or LiteLLM."""
+        if max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
         import os as _os
 
         if _os.getenv("CLTK_LOG_CONTENT", "").strip().lower() in {
@@ -345,7 +386,17 @@ class AsyncOpenAIConnection:
         for attempt in range(1, max_retries + 1):
             self.log.debug("[async] Attempt %s of %s", attempt, max_retries)
             try:
-                if "4.1" in self.model:
+                if self._is_litellm:
+                    chat_response = await self.client.chat.completions.create(
+                        model=self.model,
+                        messages=[{"role": "user", "content": prompt}],
+                        temperature=self.temperature,
+                    )
+                    content = _litellm_output_text(chat_response)
+                    openai_response = SimpleNamespace(
+                        output_text=content, usage=chat_response.usage
+                    )
+                elif "4.1" in self.model:
                     openai_response = await self.client.responses.create(
                         model=self.model,
                         input=prompt,
@@ -391,6 +442,9 @@ class AsyncOpenAIConnection:
                 "[async] Attempt %s: No code block found in response. Retrying...",
                 attempt,
             )
+
+        if not code_block:
+            raise CLTKException("No code blocks found in response after retries.")
 
         assert openai_response is not None
         usage = agg_tokens
@@ -455,3 +509,66 @@ class AsyncOpenAIConnection:
         }:
             self.log.debug("[async] Extracted code block:\n%s", code_block)
         return code_block
+
+
+class LiteLLMConnection(OpenAIConnection):
+    """Synchronous connection to models exposed by a LiteLLM proxy.
+
+    Uses ``LITELLM_API_KEY`` and defaults ``LITELLM_BASE_URL`` to the local
+    LiteLLM proxy. Requests use the provider-neutral Chat Completions endpoint;
+    model names are proxy aliases and are not restricted to OpenAI identifiers.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        temperature: float = 1.0,
+    ) -> None:
+        model = model.strip()
+        if not model:
+            raise ValueError("LiteLLM model alias cannot be empty.")
+        resolved_key = api_key or os.environ.get("LITELLM_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "LiteLLM API key required. Set LITELLM_API_KEY or pass api_key."
+            )
+        resolved_url = base_url or os.environ.get(
+            "LITELLM_BASE_URL", "http://localhost:4000/v1"
+        )
+        super().__init__(
+            model=cast(AVAILABLE_OPENAI_MODELS, model),
+            api_key=resolved_key,
+            temperature=temperature,
+            _base_url=resolved_url,
+        )
+
+
+class AsyncLiteLLMConnection(AsyncOpenAIConnection):
+    """Asynchronous connection to models exposed by a LiteLLM proxy."""
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        temperature: float = 1.0,
+    ) -> None:
+        model = model.strip()
+        if not model:
+            raise ValueError("LiteLLM model alias cannot be empty.")
+        resolved_key = api_key or os.environ.get("LITELLM_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "LiteLLM API key required. Set LITELLM_API_KEY or pass api_key."
+            )
+        resolved_url = base_url or os.environ.get(
+            "LITELLM_BASE_URL", "http://localhost:4000/v1"
+        )
+        super().__init__(
+            model=cast(AVAILABLE_OPENAI_MODELS, model),
+            api_key=resolved_key,
+            temperature=temperature,
+            _base_url=resolved_url,
+        )

--- a/src/cltk/morphosyntax/utils.py
+++ b/src/cltk/morphosyntax/utils.py
@@ -18,6 +18,7 @@ from cltk.core.data_types import (
     AVAILABLE_OPENAI_MODELS,
     CLTKGenAIResponse,
     Doc,
+    LiteLLMBackendConfig,
     MistralBackendConfig,
     ModelConfig,
     OllamaBackendConfig,
@@ -34,7 +35,12 @@ from cltk.core.provenance import (
 )
 from cltk.genai.mistral import AsyncMistralConnection, MistralConnection
 from cltk.genai.ollama import AsyncOllamaConnection, OllamaConnection
-from cltk.genai.openai import AsyncOpenAIConnection, OpenAIConnection
+from cltk.genai.openai import (
+    AsyncLiteLLMConnection,
+    AsyncOpenAIConnection,
+    LiteLLMConnection,
+    OpenAIConnection,
+)
 from cltk.genai.prompts import PromptInfo, _hash_prompt, morphosyntax_prompt
 from cltk.morphosyntax.normalization import (
     UDFeatureRemapReport,
@@ -246,6 +252,19 @@ def generate_pos(
                 model=openai_model,
                 api_key=getattr(openai_cfg, "api_key", None),
                 temperature=getattr(openai_cfg, "temperature", 1.0),
+            )
+    elif doc.backend == "litellm":
+        if not client:
+            litellm_cfg = (
+                backend_config
+                if isinstance(backend_config, LiteLLMBackendConfig)
+                else None
+            )
+            client = LiteLLMConnection(
+                model=str(doc.model),
+                api_key=getattr(litellm_cfg, "api_key", None),
+                base_url=getattr(litellm_cfg, "base_url", None),
+                temperature=getattr(litellm_cfg, "temperature", 1.0),
             )
     elif doc.backend == "mistral":
         if doc.model not in get_args(AVAILABLE_MISTRAL_MODELS):
@@ -467,6 +486,8 @@ def generate_gpt_morphosyntax(
             )
         openai_model: AVAILABLE_OPENAI_MODELS = cast(AVAILABLE_OPENAI_MODELS, doc.model)
         client = OpenAIConnection(model=openai_model)
+    elif doc.backend == "litellm":
+        client = LiteLLMConnection(model=str(doc.model))
     elif doc.backend in ("ollama", "ollama-cloud"):
         client = OllamaConnection(
             model=str(doc.model),
@@ -632,6 +653,16 @@ async def generate_gpt_morphosyntax_async(
             model=openai_model,
             api_key=getattr(openai_cfg, "api_key", None),
             temperature=getattr(openai_cfg, "temperature", 1.0),
+        )
+    elif doc.backend == "litellm":
+        litellm_cfg = (
+            backend_config if isinstance(backend_config, LiteLLMBackendConfig) else None
+        )
+        conn = AsyncLiteLLMConnection(
+            model=str(doc.model),
+            api_key=getattr(litellm_cfg, "api_key", None),
+            base_url=getattr(litellm_cfg, "base_url", None),
+            temperature=getattr(litellm_cfg, "temperature", 1.0),
         )
     elif doc.backend in ("ollama", "ollama-cloud"):
         ollama_cfg = (

--- a/src/cltk/nlp.py
+++ b/src/cltk/nlp.py
@@ -46,11 +46,11 @@ class NLP:
     Args:
       language_code: Language key (Glottolog code, ISO code, or exact name).
         Required unless ``cltk_config`` is provided.
-      backend: One of ``"stanza"`` (default), ``"openai"``, ``"ollama"``,
+      backend: One of ``"stanza"`` (default), ``"openai"``, ``"litellm"``, ``"ollama"``,
         ``"ollama-cloud"``, or ``mistral``. The ``"spacy"`` backend is not
         yet implemented and will raise ``NotImplementedError``.
       model: Optional model name when using generative backends
-        (``"openai"``, ``"ollama"``, ``"ollama-cloud"``, ``mistral``). Ignored for
+        (``"openai"``, ``"litellm"``, ``"ollama"``, ``"ollama-cloud"``, ``mistral``). Ignored for
         ``"stanza"``.
       custom_pipeline: Optional pipeline to use instead of the default mapping.
       suppress_banner: If true, suppresses informational console output.
@@ -60,6 +60,9 @@ class NLP:
     Notes:
       - When ``backend == "openai"`` and no ``model`` is provided, defaults to
         ``"gpt-5-mini"``. Requires ``OPENAI_API_KEY`` in the environment.
+      - The ``"litellm"`` backend requires a proxy model alias and
+        ``LITELLM_API_KEY``. ``LITELLM_BASE_URL`` defaults to
+        ``http://localhost:4000/v1``.
       - When ``backend`` is ``"ollama"`` or ``"ollama-cloud"`` and no ``model``
         is provided, defaults to ``"llama3.1:8b"``. ``"ollama-cloud"`` requires
         ``OLLAMA_CLOUD_API_KEY`` in the environment.
@@ -153,6 +156,19 @@ class NLP:
             # Default model if none provided
             self.model = self.model or getattr(backend_config, "model", None)
             self.model = self.model or "gpt-5-mini"
+        elif self.backend == "litellm":
+            self.api_key = getattr(backend_config, "api_key", None)
+            if not self.api_key:
+                load_env_file()
+                self.api_key = os.getenv("LITELLM_API_KEY")
+            if not self.api_key:
+                raise ValueError("API key for LiteLLM not found.")
+            self.model = self.model or getattr(backend_config, "model", None)
+            self.model = self.model or os.getenv("LITELLM_MODEL")
+            if not self.model:
+                raise ValueError(
+                    "LiteLLM model not found. Pass model or set LITELLM_MODEL."
+                )
         elif self.backend in ("ollama", "ollama-cloud"):
             if self.backend == "ollama-cloud":
                 # Prefer API key from config when provided
@@ -381,7 +397,13 @@ class NLP:
 
     def _maybe_attach_enrichment_process(self) -> None:
         """Append GenAI enrichment to generative pipelines if missing."""
-        if self.backend not in ("openai", "ollama", "ollama-cloud", "mistral"):
+        if self.backend not in (
+            "openai",
+            "litellm",
+            "ollama",
+            "ollama-cloud",
+            "mistral",
+        ):
             return
         try:
             processes = (
@@ -445,7 +467,7 @@ class NLP:
         If a custom pipeline was not provided, this looks up the mapping for
         the chosen backend and glottolog code and returns an instance. The
         ``"stanza"`` backend uses ``MAP_LANGUAGE_CODE_TO_STANZA_PIPELINE``.
-        The generative backends (``"openai"``, ``"ollama"``, ``"ollama-cloud"``)
+        The generative backends (``"openai"``, ``"litellm"``, ``"ollama"``, ``"ollama-cloud"``)
         use ``MAP_LANGUAGE_CODE_TO_GENERATIVE_PIPELINE``; the underlying client
         is selected later based on ``doc.backend``. The ``"spacy"`` backend is
         currently not implemented and raises ``NotImplementedError``.
@@ -472,7 +494,7 @@ class NLP:
             raise NotImplementedError(
                 f"Discriminative backend '{self.backend}' not yet reimplemented."
             )
-        elif self.backend == "openai":
+        elif self.backend in ("openai", "litellm"):
             mapping = MAP_LANGUAGE_CODE_TO_GENERATIVE_PIPELINE
         elif self.backend in ("ollama", "ollama-cloud"):
             # Reuse the same generative pipelines; lower layers pick the client by backend

--- a/src/cltk/translation/utils.py
+++ b/src/cltk/translation/utils.py
@@ -12,6 +12,7 @@ from cltk.core.data_types import (
     CLTKGenAIResponse,
     Doc,
     IdiomSpan,
+    LiteLLMBackendConfig,
     MistralBackendConfig,
     ModelConfig,
     OllamaBackendConfig,
@@ -30,7 +31,7 @@ from cltk.core.provenance import (
 )
 from cltk.genai.mistral import MistralConnection
 from cltk.genai.ollama import OllamaConnection
-from cltk.genai.openai import OpenAIConnection
+from cltk.genai.openai import LiteLLMConnection, OpenAIConnection
 from cltk.genai.prompts import PromptInfo, _hash_prompt, translation_prompt
 from cltk.morphosyntax.utils import _update_doc_genai_stage
 
@@ -436,6 +437,16 @@ def generate_gpt_translation(
             model=cast(AVAILABLE_OPENAI_MODELS, doc.model),
             api_key=getattr(openai_cfg, "api_key", None),
             temperature=getattr(openai_cfg, "temperature", 1.0),
+        )
+    elif doc.backend == "litellm":
+        litellm_cfg = (
+            backend_config if isinstance(backend_config, LiteLLMBackendConfig) else None
+        )
+        client = LiteLLMConnection(
+            model=str(doc.model),
+            api_key=getattr(litellm_cfg, "api_key", None),
+            base_url=getattr(litellm_cfg, "base_url", None),
+            temperature=getattr(litellm_cfg, "temperature", 1.0),
         )
     elif doc.backend in ("ollama", "ollama-cloud"):
         ollama_cfg = (

--- a/tests/genai/test_litellm_connection.py
+++ b/tests/genai/test_litellm_connection.py
@@ -1,0 +1,270 @@
+import asyncio
+import importlib
+import os
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import openai
+import pytest
+
+from cltk import NLP
+from cltk.core.data_types import CLTKConfig, LiteLLMBackendConfig
+from cltk.core.exceptions import CLTKException, OpenAIInferenceError
+
+
+def test_litellm_connection_uses_proxy_configuration(monkeypatch):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+    created: dict[str, Any] = {}
+
+    class OpenAIRecorder:
+        def __init__(self, **kwargs: Any) -> None:
+            created.update(kwargs)
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **_: SimpleNamespace(
+                        choices=[
+                            SimpleNamespace(
+                                message=SimpleNamespace(
+                                    content="```tsv\nFORM\tLEMMA\namo\tamo\n```"
+                                )
+                            )
+                        ],
+                        usage=SimpleNamespace(
+                            prompt_tokens=2, completion_tokens=3, total_tokens=5
+                        ),
+                    )
+                )
+            )
+
+    monkeypatch.setattr(module, "OpenAI", OpenAIRecorder)
+    connection = module.LiteLLMConnection(
+        model="proxy-latin", api_key="sk-test", base_url="http://proxy.test/v1/"
+    )
+
+    result = connection.generate("annotate amo", max_retries=1)
+
+    assert created == {
+        "api_key": "sk-test",
+        "base_url": "http://proxy.test/v1",
+    }
+    assert result.usage == {"input": 2, "output": 3, "total": 5}
+    assert "FORM" in result.response
+
+
+def test_litellm_connection_requires_key(monkeypatch):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="LiteLLM API key required"):
+        module.LiteLLMConnection(model="proxy-model")
+
+
+def test_litellm_connection_rejects_empty_model() -> None:
+    module = importlib.import_module("cltk.genai.openai")
+
+    with pytest.raises(ValueError, match="model alias cannot be empty"):
+        module.LiteLLMConnection(model="  ", api_key="sk-test")
+
+
+def test_litellm_connection_requires_at_least_one_attempt(monkeypatch):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+
+    class OpenAIStub:
+        def __init__(self, **_: Any) -> None:
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **_: None)
+            )
+
+    monkeypatch.setattr(module, "OpenAI", OpenAIStub)
+    connection = module.LiteLLMConnection(model="proxy-model", api_key="sk-test")
+
+    with pytest.raises(ValueError, match="max_retries must be at least 1"):
+        connection.generate("annotate amo", max_retries=0)
+
+
+def test_litellm_connection_retries_malformed_responses(monkeypatch):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+    calls = 0
+
+    class OpenAIStub:
+        def __init__(self, **_: Any) -> None:
+            def create(**_: Any) -> SimpleNamespace:
+                nonlocal calls
+                calls += 1
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(message=SimpleNamespace(content="not fenced"))
+                    ],
+                    usage=None,
+                )
+
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+    monkeypatch.setattr(module, "OpenAI", OpenAIStub)
+    connection = module.LiteLLMConnection(model="proxy-model", api_key="sk-test")
+
+    with pytest.raises(CLTKException, match="No code blocks found"):
+        connection.generate("annotate amo", max_retries=2)
+    assert calls == 2
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        SimpleNamespace(choices=[]),
+        SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=None))]
+        ),
+    ],
+    ids=["missing-choice", "null-content"],
+)
+def test_litellm_connection_rejects_empty_responses(monkeypatch, response):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+
+    class OpenAIStub:
+        def __init__(self, **_: Any) -> None:
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **_: response)
+            )
+
+    monkeypatch.setattr(module, "OpenAI", OpenAIStub)
+    connection = module.LiteLLMConnection(model="proxy-model", api_key="sk-test")
+
+    with pytest.raises(CLTKException, match="empty or malformed response"):
+        connection.generate("annotate amo", max_retries=1)
+
+
+def test_async_litellm_connection_retries_malformed_responses(monkeypatch):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+    calls = 0
+
+    class AsyncOpenAIStub:
+        def __init__(self, **_: Any) -> None:
+            async def create(**_: Any) -> SimpleNamespace:
+                nonlocal calls
+                calls += 1
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(message=SimpleNamespace(content="not fenced"))
+                    ],
+                    usage=None,
+                )
+
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+    monkeypatch.setattr(module, "AsyncOpenAI", AsyncOpenAIStub)
+    connection = module.AsyncLiteLLMConnection(model="proxy-model", api_key="sk-test")
+
+    async def run() -> None:
+        with pytest.raises(CLTKException, match="No code blocks found"):
+            await connection.generate_async("annotate amo", max_retries=2)
+
+    asyncio.run(run())
+    assert calls == 2
+
+
+def _status_error(
+    error_type: type[openai.APIStatusError], status: int
+) -> openai.APIStatusError:
+    request = httpx.Request("POST", "http://proxy.test/v1/responses")
+    response = httpx.Response(status, request=request)
+    return error_type(
+        "gateway rejected request",
+        response=response,
+        body={"error": {"message": "gateway rejected request"}},
+    )
+
+
+@pytest.mark.parametrize(
+    "sdk_error",
+    [
+        pytest.param(
+            _status_error(openai.AuthenticationError, 401), id="invalid-api-key"
+        ),
+        pytest.param(_status_error(openai.NotFoundError, 404), id="model-not-found"),
+        pytest.param(_status_error(openai.RateLimitError, 429), id="rate-limit"),
+        pytest.param(
+            _status_error(openai.BadRequestError, 400), id="context-window-exceeded"
+        ),
+        pytest.param(
+            openai.APITimeoutError(
+                request=httpx.Request("POST", "http://proxy.test/v1/responses")
+            ),
+            id="timeout",
+        ),
+    ],
+)
+def test_litellm_connection_wraps_sdk_errors(monkeypatch, sdk_error):  # type: ignore[no-untyped-def]
+    module = importlib.import_module("cltk.genai.openai")
+
+    class OpenAIStub:
+        def __init__(self, **_: Any) -> None:
+            def create(**_: Any) -> None:
+                raise sdk_error
+
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+    monkeypatch.setattr(module, "OpenAI", OpenAIStub)
+    connection = module.LiteLLMConnection(model="proxy-model", api_key="sk-test")
+
+    with pytest.raises(OpenAIInferenceError, match="An error from OpenAI occurred"):
+        connection.generate("annotate amo", max_retries=1)
+
+
+def test_litellm_backend_config_is_selected() -> None:
+    config = CLTKConfig(
+        language_code="lati1261",
+        backend="litellm",
+        litellm=LiteLLMBackendConfig(
+            model="proxy-latin",
+            api_key="sk-test",
+            base_url="https://proxy.test/v1",
+        ),
+    )
+
+    assert config.active_backend_config is config.litellm
+    assert config.litellm is not None
+    assert config.litellm.model == "proxy-latin"
+
+
+def test_nlp_initializes_litellm_backend() -> None:
+    config = CLTKConfig(
+        language_code="lati1261",
+        backend="litellm",
+        suppress_banner=True,
+        litellm=LiteLLMBackendConfig(model="proxy-latin", api_key="sk-test"),
+    )
+
+    nlp = NLP(cltk_config=config)
+
+    assert nlp.backend == "litellm"
+    assert nlp.model == "proxy-latin"
+    assert nlp.pipeline is not None
+
+
+@pytest.mark.skipif(
+    not all(
+        os.environ.get(name)
+        for name in (
+            "LITELLM_E2E_BASE_URL",
+            "LITELLM_E2E_API_KEY",
+            "LITELLM_E2E_MODEL",
+        )
+    ),
+    reason="LiteLLM live E2E environment is not configured",
+)
+def test_litellm_live_e2e() -> None:
+    module = importlib.import_module("cltk.genai.openai")
+    connection = module.LiteLLMConnection(
+        model=os.environ["LITELLM_E2E_MODEL"],
+        api_key=os.environ["LITELLM_E2E_API_KEY"],
+        base_url=os.environ["LITELLM_E2E_BASE_URL"],
+        temperature=0,
+    )
+
+    result = connection.generate(
+        "Return exactly this fenced block: ```text\nOK\n```", max_retries=1
+    )
+
+    assert "OK" in result.response


### PR DESCRIPTION
## Summary

Adds LiteLLM as a first-class CLTK generative backend for synchronous and asynchronous NLP pipelines.

The backend uses LiteLLM's OpenAI-compatible Chat Completions endpoint, so a CLTK pipeline can select any model alias configured by the gateway, including aliases backed by OpenAI, Anthropic, Azure, or gateway fallback routes.


## Changes

- add `litellm` to CLTK's supported backend configuration
- add `LiteLLMBackendConfig` with model alias, base URL, API key, temperature, and retry settings
- add synchronous and asynchronous LiteLLM connections
- route dependency parsing, morphosyntax, enrichment, and translation through LiteLLM
- preserve CLTK's structured fenced-response parsing and token accounting
- reject missing credentials, empty model aliases, empty responses, and malformed responses with explicit errors
- document environment-variable and structured-config usage
- add mocked, error-path, configuration, async, and opt-in live E2E tests

## Usage

```python
import os

from cltk import NLP

os.environ["LITELLM_API_KEY"] = "your-gateway-key"
os.environ["LITELLM_BASE_URL"] = "https://litellm.example.com/v1"

nlp = NLP(
    "lati1261",
    backend="litellm",
    model="your-proxy-model-alias",
)

doc = nlp.analyze(text="Gallia est omnis divisa in partes tres.")
```

`your-proxy-model-alias` is a gateway alias, not a fixed CLTK model. Different `NLP` instances may select different aliases, and LiteLLM can apply provider routing or fallback behavior behind each alias.

## Tests

- full test suite: `62 passed, 2 skipped, 6 deselected`
- LiteLLM-focused tests: `15 passed, 1 opt-in E2E skipped` without live environment variables
- Ruff lint and formatting checks pass for every changed Python file
- live E2E passed against a running LiteLLM proxy with an Azure OpenAI-backed model alias, exercising the real Chat Completions response shape and CLTK fenced-block parser
- verified SDK error handling for invalid credentials, unknown models, rate limits, context-window errors, and timeouts
- verified retry exhaustion and explicit rejection of missing choices, null content, and unfenced responses

The running gateway's configured Azure Anthropic deployment currently rejects requests at the upstream account-access layer; CLTK correctly surfaces that SDK failure as `OpenAIInferenceError`. Provider-specific routing remains owned by LiteLLM, while CLTK consumes the same OpenAI-compatible response contract for every alias.

## Compatibility

- no new required dependency; the backend reuses the existing `cltk[openai]` extra
- existing backends retain their current configuration paths
- API keys default to environment variables and are not logged
- LiteLLM requests are intentionally non-streaming because the existing CLTK generative pipelines parse complete structured responses
